### PR TITLE
feat(utils/cache): changed getSchema cache to TTL cache

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,7 +8,7 @@
 yarn.lock
 .env
 /testing-functions
-/test
 /testapp
 /src
 /pkg
+/tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "ethers5": "npm:ethers@^5.7.2",
         "jssha": "^3.2.0",
         "long": "^5.2.1",
-        "node-fetch": "^3.3.0",
         "protobufjs": "^7.1.2"
       },
       "devDependencies": {
@@ -4325,14 +4324,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "engines": {
-        "node": ">= 12"
-      }
-    },
     "node_modules/dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -5143,28 +5134,6 @@
         "bser": "2.1.1"
       }
     },
-    "node_modules/fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "dependencies": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      },
-      "engines": {
-        "node": "^12.20 || >= 14.13"
-      }
-    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -5309,17 +5278,6 @@
       },
       "engines": {
         "node": ">= 6"
-      }
-    },
-    "node_modules/formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "dependencies": {
-        "fetch-blob": "^3.1.2"
-      },
-      "engines": {
-        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-extra": {
@@ -7382,41 +7340,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node_modules/node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/jimmywarting"
-        },
-        {
-          "type": "github",
-          "url": "https://paypal.me/jimmywarting"
-        }
-      ],
-      "engines": {
-        "node": ">=10.5.0"
-      }
-    },
-    "node_modules/node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "dependencies": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/node-fetch"
-      }
-    },
     "node_modules/node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -9187,14 +9110,6 @@
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
-      }
-    },
-    "node_modules/web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
-      "engines": {
-        "node": ">= 8"
       }
     },
     "node_modules/which": {
@@ -12464,11 +12379,6 @@
       "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
       "dev": true
     },
-    "data-uri-to-buffer": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
-      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
-    },
     "dateformat": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -13073,15 +12983,6 @@
         "bser": "2.1.1"
       }
     },
-    "fetch-blob": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
-      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
-      "requires": {
-        "node-domexception": "^1.0.0",
-        "web-streams-polyfill": "^3.0.3"
-      }
-    },
     "figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -13184,14 +13085,6 @@
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "mime-types": "^2.1.12"
-      }
-    },
-    "formdata-polyfill": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
-      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
-      "requires": {
-        "fetch-blob": "^3.1.2"
       }
     },
     "fs-extra": {
@@ -14757,21 +14650,6 @@
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
     },
-    "node-domexception": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
-      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
-    },
-    "node-fetch": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.0.tgz",
-      "integrity": "sha512-BKwRP/O0UvoMKp7GNdwPlObhYGB5DQqwhEDQlNKuoqwVYSxkSZCSbHjnFFmUEtwSKRPU4kNK8PbDYYitwaE3QA==",
-      "requires": {
-        "data-uri-to-buffer": "^4.0.0",
-        "fetch-blob": "^3.1.4",
-        "formdata-polyfill": "^4.0.10"
-      }
-    },
     "node-int64": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
@@ -16067,11 +15945,6 @@
       "requires": {
         "defaults": "^1.0.3"
       }
-    },
-    "web-streams-polyfill": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
-      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
     },
     "which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "pack_post": "copyfiles ./kwil*.tgz ./pkg && rimraf ./kwil*.tgz",
     "pack": "npm run pack_build && npm run pack_pre && npm --prefix ./dist pack && npm run pack_post"
   },
-  "author": "",
+  "author": "Kwil, Inc. <luke@kwil.com>",
   "license": "MIT",
   "devDependencies": {
     "@commitlint/cli": "^17.7.1",
@@ -54,7 +54,6 @@
     "ethers5": "npm:ethers@^5.7.2",
     "jssha": "^3.2.0",
     "long": "^5.2.1",
-    "node-fetch": "^3.3.0",
     "protobufjs": "^7.1.2"
   },
   "engines": {

--- a/src/api_client/api.ts
+++ b/src/api_client/api.ts
@@ -30,7 +30,8 @@ export abstract class Api {
             apiKey: opts.apiKey || '',
             logging: opts.logging || false,
             logger: opts.logger || console.log,
-            network: opts.network
+            network: opts.network,
+            cache: opts.cache || 10 * 60,
         };
     }
 

--- a/src/api_client/config.ts
+++ b/src/api_client/config.ts
@@ -1,4 +1,17 @@
 // config for api
+
+type seconds = number
+
+/**
+ * @typedef {Object} Config
+ * @property {string} kwilProvider - kwil provider url
+ * @property {number} [timeout] - timeout for requests in milliseconds
+ * @property {string} [apiKey] - api key for kwil provider, if required (not required for public networks)
+ * @property {boolean} [logging] - enable logging
+ * @property {Function} [logger] - custom logger function
+ * @property {string} [network] - network to use (mainnet, testnet, etc.)
+ * @property {number} [cache] - Time to live cache in seconds. Only getSchema requests are cached. Default is 10 minutes.
+ */
 export interface Config {
     kwilProvider: string;
     timeout?: number;
@@ -6,4 +19,5 @@ export interface Config {
     logging?: boolean;
     logger?: Function;
     network?: string;
+    cache?: seconds;
 }

--- a/src/client/kwil.ts
+++ b/src/client/kwil.ts
@@ -1,21 +1,22 @@
-import {generateDBID} from "../utils/dbid";
+import { generateDBID } from "../utils/dbid";
 import Client from "../api_client/client";
 import { Config } from "../api_client/config";
-import {GenericResponse} from "../core/resreq";
-import {Database, SelectQuery} from "../core/database";
-import {Transaction, TxReceipt} from "../core/tx";
-import {Account} from "../core/account";
-import {ethers, Signer} from "ethers";
-import {Funder} from "../funder/funding";
-import {ActionBuilderImpl} from "../builders/action_builder";
-import {base64ToBytes} from "../utils/base64";
-import {DBBuilderImpl} from "../builders/db_builder";
-import {DropDBBuilderImpl} from "../builders/drop_db_builder";
-import {NonNil} from "../utils/types";
-import {ActionBuilder, DBBuilder} from "../core/builders";
-import {wrap} from "./intern";
+import { GenericResponse } from "../core/resreq";
+import { Database, SelectQuery } from "../core/database";
+import { Transaction, TxReceipt } from "../core/tx";
+import { Account } from "../core/account";
+import { ethers, Signer } from "ethers";
+import { Funder } from "../funder/funding";
+import { ActionBuilderImpl } from "../builders/action_builder";
+import { base64ToBytes } from "../utils/base64";
+import { DBBuilderImpl } from "../builders/db_builder";
+import { DropDBBuilderImpl } from "../builders/drop_db_builder";
+import { NonNil } from "../utils/types";
+import { ActionBuilder, DBBuilder } from "../core/builders";
+import { wrap } from "./intern";
 import { FundingConfig } from "../core/configs";
 import { Signer as Signerv5, Wallet as Walletv5 } from "ethers5"
+import { Cache } from "../utils/cache";
 
 /**
  * The main class for interacting with the Kwil network.
@@ -24,7 +25,7 @@ import { Signer as Signerv5, Wallet as Walletv5 } from "ethers5"
 export abstract class Kwil {
     private readonly client: Client;
     //cache schemas
-    private schemas?: Map<string, GenericResponse<Database<string>>>;
+    private schemas: Cache<GenericResponse<Database<string>>>;
 
     // cache fundingConfig
     private fundingConfig?: GenericResponse<FundingConfig>;
@@ -37,8 +38,10 @@ export abstract class Kwil {
             timeout: opts.timeout,
             logging: opts.logging,
             logger: opts.logger,
+            cache: opts.cache,
         });
 
+        this.schemas = Cache.passive(opts.cache);
         wrap(this, this.client.estimateCost.bind(this.client));
     }
 
@@ -62,19 +65,17 @@ export abstract class Kwil {
      */
 
     public async getSchema(dbid: string): Promise<GenericResponse<Database<string>>> {
-        //check cache
-        if (this.schemas && this.schemas.has(dbid)) {
-            return this.schemas.get(dbid) as GenericResponse<Database<string>>;
+        // check cache
+        const schema = this.schemas.get(dbid)
+        if (schema) {
+            return schema;
         }
 
         //fetch from server
         const res = await this.client.getSchema(dbid);
 
         //cache result
-        if (res.status == 200) {
-            if (!this.schemas) {
-                this.schemas = new Map<string, GenericResponse<Database<string>>>();
-            }
+        if (res.status === 200) {
             this.schemas.set(dbid, res);
         }
 
@@ -113,15 +114,15 @@ export abstract class Kwil {
         return DBBuilderImpl.of(this);
     }
 
-     /**
-     * Returns an instance of Drop Database Builder for this client.
-     *
-     * @returns A Drop Database Builder instance. Drop Database Builder is used to build drop database transactions to be broadcasted to the Kwil network.
-     */
+    /**
+    * Returns an instance of Drop Database Builder for this client.
+    *
+    * @returns A Drop Database Builder instance. Drop Database Builder is used to build drop database transactions to be broadcasted to the Kwil network.
+    */
 
-     public dropDBBuilder(): NonNil<DBBuilder> {
+    public dropDBBuilder(): NonNil<DBBuilder> {
         return DropDBBuilderImpl.of(this);
-     }
+    }
 
     /**
      * Broadcasts a transaction on the network.
@@ -167,13 +168,13 @@ export abstract class Kwil {
 
     public async getFunder(signer: Signer | ethers.Wallet | Signerv5 | Walletv5): Promise<Funder> {
         //check cache
-        if(!this.fundingConfig || !this.fundingConfig.data) {
+        if (!this.fundingConfig || !this.fundingConfig.data) {
             this.fundingConfig = await this.client.getFundingConfig();
             if (this.fundingConfig.status != 200 || !this.fundingConfig.data) {
                 throw new Error('Failed to get funding config.');
             }
         }
-        
+
         return await Funder.create(signer, this.fundingConfig.data);
     }
 

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -1,0 +1,145 @@
+import { Nillable } from './types';
+
+export namespace Cache {
+    /**
+     * Create a new TTL cache that proactively checks for expired items at regular intervals (defined by cleanupIntervalSeconds).
+        * @param ttlSeconds - Time to live for each cache entry in seconds. If none is specified, it defaults to 10 minutes.
+        * @param cleanupIntervalSeconds - Interval in seconds between each cleanup run. If not set, it defaults to 60 seconds. If set to -1, the cache will run in passive mode and only check for expired items when get() is called.
+        * @returns Cache<T>
+    */
+    export function active<T>(ttlSeconds: number = 10 * 60, cleanupIntervalSeconds: number = 60): Cache<T> {
+        return new TtlCache<T>(ttlSeconds, cleanupIntervalSeconds);
+    }
+
+    /** 
+     * Create a new TTL cache that only checks for expired items when get() is called.
+     * @param ttlSeconds - Time to live for each cache entry in seconds. If none is specified, it defaults to 10 minutes.
+     * @returns Cache<T>
+    */
+    export function passive<T>(ttlSeconds: number = 10 * 60): Cache<T> {
+        return new TtlCache<T>(ttlSeconds, -1);
+    }
+}
+
+export interface Cache<T> {
+    get(k: string): Nillable<T>;
+    set(k: string, v: T): void;
+    shutdown(): void;
+}
+
+class TtlCache<T> {
+    private readonly cache: Map<string, { d: number, v: any }>;
+    private readonly ttl: number;
+    private readonly cleanupIntervalSeconds: number;
+    private readonly cleanupQueue: { d: number, k: string }[];
+    private cleanupTimerId: any;
+
+    constructor(ttlSeconds: number, cleanupIntervalSeconds: number) {
+        this.cache = new Map<string, { d: number, v: any }>();
+        this.ttl = ttlSeconds * 1000;
+        this.cleanupIntervalSeconds = cleanupIntervalSeconds;
+        this.cleanupQueue = [];
+
+        console.log(`Cache TTL set to ${this.ttl} milliseconds.`)
+        if (!this.isPassiveMode()) {
+            console.log(`Cache cleanup interval set to ${cleanupIntervalSeconds} seconds.`)
+        } else {
+            console.log(`Cache cleanup running in passive mode.`)
+        }
+    }
+
+    /**
+     * Set a value in the cache
+     * @param k - Key for the cache entry.
+     * @param v - Value to be stored.
+     */
+    public set(k: string, v: T): void {
+        this.ensureCleanRunning();
+        const d = Date.now() + this.ttl;
+        this.cache.set(k, { d, v });
+        if (!this.isPassiveMode()) {
+            this.cleanupQueue.push({ d, k });
+        }
+    }
+
+    /**
+     * Get a value from the cache. If the value is not found or has expired, null is returned.
+     * @param k - Key for the cache entry.
+     * @param v - Value to be stored.
+    */
+    public get(k: string): Nillable<T> {
+        const entry = this.cache.get(k);
+
+        if (entry && entry.d < Date.now()) {
+            this.cache.delete(k);
+            return null;
+        }
+
+        return entry?.v || null;
+    }
+
+    /**
+     * This will shutdown the cache cleanup timer.
+     * @returns void
+    */
+    public shutdown(): void {
+        if (this.cleanupTimerId) {
+            clearInterval(this.cleanupTimerId);
+        }
+    }
+
+    /**
+     * Ensures that the background cleanup is running and the timer is set.
+     * @returns void
+     * @private
+     */
+    private ensureCleanRunning(): void {
+        if (this.isPassiveMode()) {
+            return;
+        }
+
+        if (!this.cleanupTimerId) {
+            this.cleanupTimerId =
+                setInterval(
+                    this.cleanup.bind(this),
+                    this.cleanupIntervalSeconds * 1000
+                );
+
+            console.log(`Background cache cleanup started. Interval of ${this.cleanupIntervalSeconds} seconds between cleaup.`)
+        }
+    }
+
+    /**
+     * Checks if the cache is running in passive mode.
+     * @returns boolean
+     * @private
+     */
+    private isPassiveMode(): boolean {
+        return this.cleanupIntervalSeconds <= 0;
+    }
+
+    /**
+     * Cleanup the cache. This will remove all expired entries from the cache.
+     * @returns void
+     * @private
+    */
+    private cleanup(): void {
+        let removed = 0;
+        while (this.cleanupQueue.length > 0) {
+            const entry = this.cleanupQueue[0];
+            if (entry.d > Date.now()) {
+                break;
+            }
+
+            const cacheEntry = this.cache.get(entry.k);
+            if (cacheEntry && cacheEntry.d < Date.now()) {
+                this.cache.delete(entry.k);
+                removed++;
+            }
+
+            this.cleanupQueue.shift();
+        }
+
+        console.log(`Running background cache cleanup. Removed ${removed} entries.`)
+    }
+}

--- a/tests/ethers5.test.ts
+++ b/tests/ethers5.test.ts
@@ -9,14 +9,14 @@ import { ActionBuilderImpl } from "../dist/builders/action_builder";
 import { Transaction, TxReceipt } from "../dist/core/tx";
 require('dotenv').config();
 
-const provider = new providers.InfuraProvider("goerli")
+const provider = process.env.ETH_PROVIDER === "https://provider.kwil.com" ? new providers.InfuraProvider("goerli") : process.env.ETH_PROVIDER ? new providers.JsonRpcProvider(process.env.ETH_PROVIDER) : new providers.JsonRpcProvider("http://localhost:8545");
 const wallet = new Wallet(process.env.PRIVATE_KEY as string, provider);
 
 const dbid = kwil.getDBID(wallet.address, "mydb")
 
 describe("All node funder operations should work with Ethersv5 Wallet and Signer", () => {
     const kwil = new NodeKwil({
-        kwilProvider: "https://provider.kwil.com",
+        kwilProvider: process.env.KWIL_PROVIDER || 'should fail',
         timeout: 10000,
         logging: true,
     })
@@ -36,7 +36,7 @@ describe("All node funder operations should work with Ethersv5 Wallet and Signer
         expect(funder).toMatchObject<FunderObj>({
             poolAddress: expect.any(String),
             signer: expect.objectContaining({
-                address: '0xAfFDC06cF34aFD7D5801A13d48C92AD39609901D',
+                address: wallet.address,
                 provider: expect.any(Object),
             }),
             providerAddress: expect.any(String),

--- a/tests/test_schema2.json
+++ b/tests/test_schema2.json
@@ -104,7 +104,7 @@
                 "$age"
             ],
             "statements": [
-                "INSERT INTO users( id , username , age , wallet ) VALUES ( $id , $username , $age , @caller )"
+                "INSERT INTO users( id , username , age , wallet ) VALUES ( $id , $username , $age , @caller );"
             ]
         },
         {
@@ -114,7 +114,7 @@
                 "$username"
             ],
             "statements": [
-                "UPDATE users SET username = $username WHERE wallet = @caller"
+                "UPDATE users SET username = $username WHERE wallet = @caller;"
             ]
         },
         {
@@ -122,7 +122,7 @@
             "public": true,
             "inputs": [],
             "statements": [
-                "DELETE FROM users WHERE wallet = @caller"
+                "DELETE FROM users WHERE wallet = @caller;"
             ]
         },
         {
@@ -134,7 +134,7 @@
                 "$content"
             ],
             "statements": [
-                "INSERT INTO posts( id , user_id , title , content ) VALUES ( $id , ( SELECT id FROM users WHERE wallet = @caller ) , $title , $content )"
+                "INSERT INTO posts( id , user_id , title , content ) VALUES ( $id , ( SELECT id FROM users WHERE wallet = @caller ) , $title , $content );"
             ]
         },
         {
@@ -144,7 +144,7 @@
                 "$id"
             ],
             "statements": [
-                "DELETE FROM posts WHERE id = $id AND user_id =( SELECT id FROM users WHERE wallet = @caller )"
+                "DELETE FROM posts WHERE id = $id AND user_id =( SELECT id FROM users WHERE wallet = @caller );"
             ]
         },
         {
@@ -154,7 +154,7 @@
                 "$address"
             ],
             "statements": [
-                "SELECT * FROM users WHERE wallet = $address"
+                "SELECT * FROM users WHERE wallet = $address;"
             ]
         },
         {
@@ -162,7 +162,7 @@
             "public": false,
             "inputs": [],
             "statements": [
-                "SELECT * FROM users"
+                "SELECT * FROM users;"
             ]
         },
         {
@@ -172,7 +172,7 @@
                 "$username"
             ],
             "statements": [
-                "SELECT title , content FROM posts WHERE user_id =( SELECT id FROM users WHERE username = $username )"
+                "SELECT title , content FROM posts WHERE user_id =( SELECT id FROM users WHERE username = $username );"
             ]
         },
         {
@@ -180,8 +180,8 @@
             "public": true,
             "inputs": [],
             "statements": [
-                "SELECT * FROM posts",
-                "SELECT * FROM users"
+                "SELECT * FROM posts;",
+                "SELECT * FROM users;"
             ]
         }
     ]

--- a/tests/testingUtils.ts
+++ b/tests/testingUtils.ts
@@ -58,9 +58,9 @@ export interface ActionObj {
 
 
 export const kwil = new NodeKwil({
-    kwilProvider: "https://provider.kwil.com",
+    kwilProvider: process.env.KWIL_PROVIDER || "SHOULD FAIL",
     timeout: 10000,
-    logging: true,
+    logging: true
 })
 
 export const dbid = kwil.getDBID(wallet.address, "mydb")

--- a/tests/unitTests/api_client/api-utils.ts
+++ b/tests/unitTests/api_client/api-utils.ts
@@ -1,0 +1,34 @@
+import Axios from 'axios';
+
+const getMock = jest.fn();
+const postMock = jest.fn();
+const requestMock = jest.fn();
+
+const requestInterceptors: any[] = [];
+const responseInterceptors: any[] = [];
+
+jest.mock('axios', () => ({
+  create: jest.fn(() => ({
+    get: getMock,
+    post: postMock,
+    interceptors: {
+      request: {
+        use: jest.fn((handler: any) => {
+          requestInterceptors.push(handler);
+          return 1; // Mocking the ID returned by Axios, which usually would be used for ejecting the interceptor later.
+        }),
+      },
+      response: {
+        use: jest.fn((handler: any) => {
+          responseInterceptors.push(handler);
+          return 1;
+        }),
+      },
+    }
+  })),
+}));
+
+const mockedAxios = Axios as jest.Mocked<typeof Axios>;
+
+
+export { mockedAxios, getMock, postMock, requestInterceptors, responseInterceptors, requestMock };

--- a/tests/unitTests/api_client/api.test.ts
+++ b/tests/unitTests/api_client/api.test.ts
@@ -1,0 +1,104 @@
+import { mockedAxios, getMock, postMock, requestInterceptors } from './api-utils';
+import { Api } from '../../../src/api_client/api';
+import { Config } from '../../../src/api_client/config';
+require('dotenv').config();
+
+
+class TestApi extends Api {
+    public constructor(host: string, opts: Config) {
+        super(host, opts);
+    }
+}
+
+describe('Api', () => {
+
+  const defaultConfig = {
+    kwilProvider: "shouldn't matter",
+    timeout: 10000,
+    apiKey: '',
+    logging: false,
+    logger: console.log,
+    network: undefined,
+    cache: 10 * 60
+  };
+
+  describe('mergeDefaults', () => {
+    it('should merge default options', () => {
+      const api = new TestApi('http://test.com', defaultConfig);
+      const result = api['mergeDefaults'](defaultConfig);
+      expect(result).toEqual(defaultConfig);
+    });
+  });
+
+  describe('get', () => {
+    it('should handle successful get request', async () => {
+      getMock.mockResolvedValue({ data: 'success' });
+
+      const api = new TestApi('http://test.com', defaultConfig);
+      const response = await api['get']('testEndpoint');
+      expect(response.data).toBe('success');
+    });
+
+    it('should handle error get request', async () => {
+      getMock.mockRejectedValue({
+        response: {
+          status: 400,
+          data: 'error'
+        }
+      });
+
+      const api = new TestApi('http://test.com', defaultConfig);
+      const response = await api['get']('testEndpoint');
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('post', () => {
+    it('should handle successful post request', async () => {
+      postMock.mockResolvedValue({ data: 'success' });
+
+      const api = new TestApi('http://test.com', defaultConfig);
+      const response = await api['post']('testEndpoint', {});
+      expect(response.data).toBe('success');
+    });
+
+    it('should handle error post request', async () => {
+      postMock.mockRejectedValue({
+        response: {
+          status: 400,
+          data: 'error'
+        }
+      });
+
+      const api = new TestApi('http://test.com', defaultConfig);
+      const response = await api['post']('testEndpoint', {});
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe('request', () => {
+    it('should create axios instance with correct headers', () => {
+      const api = new TestApi('http://test.com', defaultConfig);
+      api['request']();
+      expect(mockedAxios.create).toHaveBeenCalledWith(expect.objectContaining({
+        headers: expect.objectContaining({
+          "X-Api-Key": expect.any(String),
+        }),
+      }));
+    });
+
+    it('should add logging interceptors if logging is enabled', () => {
+        const loggerMock = jest.fn();
+        const api = new TestApi('http://test.com', { ...defaultConfig, logging: true, logger: loggerMock });
+        api['request']();
+        
+        // Check if a request interceptor was added.
+        expect(requestInterceptors.length).toBeGreaterThan(0);
+      
+        // You could also simulate a request to see if the logger gets called
+        const dummyRequest = { baseURL: 'http://test.com', url: '/dummy' };
+        requestInterceptors[0](dummyRequest);
+        expect(loggerMock).toHaveBeenCalledWith('Requesting: http://test.com/dummy');
+      });
+  });
+});

--- a/tests/unitTests/api_client/client.test.ts
+++ b/tests/unitTests/api_client/client.test.ts
@@ -1,0 +1,230 @@
+
+import { getMock, postMock } from './api-utils';
+import Client from "../../../src/api_client/client";
+import { PayloadType, Transaction } from "../../../src/core/tx";
+require('dotenv').config();
+
+describe('Client', () => {
+    let client: Client;
+    const mockConfig = {
+        kwilProvider: 'https://shouldntmatter.com',
+        timeout: 10000,
+        apiKey: '',
+        logging: false,
+        logger: jest.fn(),
+        network: ''
+    };
+
+    beforeEach(() => {
+        client = new Client(mockConfig);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    })
+
+    it('should get funding config', async () => {
+        getMock.mockResolvedValue({ status: 200, data: 1 });
+
+        const result = await client.getFundingConfig();
+        expect(result.status).toBe(200);
+        expect(result.data).toBe(1);
+
+        expect(getMock).toHaveBeenCalledWith('/api/v1/config', undefined);
+    });
+
+    describe('getSchema', () => {
+        it('should get schema if schema exists', async () => {
+            getMock.mockResolvedValue({
+                status: 200,
+                data: { dataset: 'mockDataset' }
+            });
+            const result = await client.getSchema('someDbId');
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual('mockDataset');
+            expect(getMock).toHaveBeenCalledWith('/api/v1/databases/someDbId/schema', undefined);
+        });
+
+        it('should throw error if schema does not exist', async () => {
+            const mockRes = {
+                status: 400
+            };
+
+            getMock.mockResolvedValue(mockRes);
+
+            await expect(client.getSchema('someDbId')).rejects.toThrow('An unknown error has occurred.  Please check your network connection.');
+            expect(getMock).toHaveBeenCalledWith('/api/v1/databases/someDbId/schema', undefined);
+        });
+    });
+
+    describe('getAccount', () => {
+        it('should get account if account exists', async () => {
+            getMock.mockResolvedValue({
+                status: 200,
+                data: { account: 'mockAccount' }
+            });
+            const result = await client.getAccount('someAddress');
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual('mockAccount');
+            expect(getMock).toHaveBeenCalledWith('/api/v1/accounts/someAddress', undefined);
+        });
+
+        it('should throw error if account does not exist', async () => {
+            const mockRes = {
+                status: 400
+            };
+
+            getMock.mockResolvedValue(mockRes);
+
+            await expect(client.getAccount('someAddress')).rejects.toThrow('An unknown error has occurred.  Please check your network connection.');
+            expect(getMock).toHaveBeenCalledWith('/api/v1/accounts/someAddress', undefined);
+        });
+    })
+
+    describe('listDatabases', () => {
+        it('should list databases if wallet exists', async () => {
+            getMock.mockResolvedValue({
+                status: 200,
+                data: { databases: ['mockDatabase1', 'mockDatabase2'] }
+            });
+            const result = await client.listDatabases("someAddress");
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual(['mockDatabase1', 'mockDatabase2']);
+            expect(getMock).toHaveBeenCalledWith('/api/v1/someAddress/databases', undefined);
+        });
+
+        it('should throw error if databases do not exist', async () => {
+            const mockRes = {
+                status: 400,
+                data: "No databases for wallet"
+            };
+
+            getMock.mockResolvedValue(mockRes);
+
+            await expect(client.listDatabases('someAddress')).rejects.toThrow('No databases for wallet');
+            expect(getMock).toHaveBeenCalledWith('/api/v1/someAddress/databases', undefined);
+        });
+    });
+
+    describe('estimateCost', () => {
+        it('should estimate cost for a transaction', async () => {
+            const tx = new Transaction();
+            postMock.mockResolvedValue({
+                status: 200,
+                data: { price: 1 }
+            });
+            const result = await client.estimateCost(tx);
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual(1);
+            expect(postMock).toHaveBeenCalled();
+        });
+
+        it('should throw error if estimate cost fails', async () => {
+            const tx = new Transaction();
+            const mockRes = {
+                status: 400,
+                data: "Error estimating cost"
+            };
+
+            postMock.mockResolvedValue(mockRes);
+
+            await expect(client.estimateCost(tx)).rejects.toThrow('Error estimating cost');
+            expect(postMock).toHaveBeenCalled();
+        });
+    })
+
+    describe('broadcast', () => {
+        it('should throw an error when broadcasting an unsigned transaction', async () => {
+            const tx = new Transaction(); // Assuming this transaction is unsigned by default
+            await expect(client.broadcast(tx)).rejects.toThrow('Tx must be signed before broadcasting.');
+        });
+
+        it('should broadcast a signed transaction', async () => {
+            const tx = new Transaction({
+                hash: 'mockHash',
+                payload_type: PayloadType.EXECUTE_ACTION,
+                payload: 'mockPayload',
+                fee: 'mockFee',
+                nonce: 1,
+                sender: 'mockSender',
+                signature: {
+                    signature_bytes: 'mockSignatureBytes',
+                    signature_type: 1
+                }
+            })
+
+            postMock.mockResolvedValue({
+                status: 200,
+                data: { receipt: { txHash: '3D/Em+hqmZYG/Zl7+Jfsag0B1hjD/t3Z/42tk2xru8ecmCD14dY4OZ6q11o3PuEP', fee: 'mockFee', body: 'W10=' } }
+            });
+
+            const result = await client.broadcast(tx);
+
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual({
+                txHash: '0xdc3fc49be86a999606fd997bf897ec6a0d01d618c3feddd9ff8dad936c6bbbc79c9820f5e1d638399eaad75a373ee10f',
+                fee: 'mockFee',
+                body: []
+            });
+            expect(postMock).toHaveBeenCalledWith('/api/v1/broadcast', { tx }, undefined);
+        });
+    });
+
+    describe('ping', () => {
+        it('should ping', async () => {
+            getMock.mockResolvedValue({
+                status: 200,
+                data: { message: 'pong' }
+            });
+            const result = await client.ping();
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual('pong');
+            expect(getMock).toHaveBeenCalledWith('/api/v1/ping', undefined);
+        });
+
+        it('should throw error if ping fails', async () => {
+            const mockRes = {
+                status: 400,
+                data: "Error pinging"
+            };
+
+            getMock.mockResolvedValue(mockRes);
+
+            await expect(client.ping()).rejects.toThrow('Error pinging');
+            expect(getMock).toHaveBeenCalledWith('/api/v1/ping', undefined);
+        });
+    });
+
+    describe('selectQuery', () => {
+        it('should select query', async () => {
+            const query = {
+                dbid: 'mockDatabase',
+                query: 'mockQuery'
+            }
+            postMock.mockResolvedValue({
+                status: 200,
+                data: { result: 'mockResult' }
+            });
+            const result = await client.selectQuery(query);
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual('mockResult');
+            expect(postMock).toHaveBeenCalledWith('/api/v1/query', query, undefined);
+        });
+
+        it('should throw error if select query fails', async () => {
+            const query = {
+                dbid: 'mockDatabase',
+                query: 'mockQuery'
+            }
+            const mockRes = {
+                status: 400,
+                data: "Error selecting query"
+            };
+
+            postMock.mockResolvedValue(mockRes);
+
+            await expect(client.selectQuery(query)).rejects.toThrow('Error selecting query');
+            expect(postMock).toHaveBeenCalledWith('/api/v1/query', query, undefined);
+        });
+    });
+});

--- a/tests/unitTests/builders/action_builder.test.ts
+++ b/tests/unitTests/builders/action_builder.test.ts
@@ -1,0 +1,202 @@
+import { getMock, postMock } from '../api_client/api-utils';
+import { ActionBuilderImpl } from '../../../src/builders/action_builder';
+import { ActionBuilder } from '../../../src/core/builders';
+import { Kwil } from '../../../src/client/kwil';
+import { Wallet } from 'ethers';
+import { ActionInput } from '../../../src/core/actionInput';
+import { Transaction } from '../../../src/core/tx';
+
+class TestKwil extends Kwil {
+    public constructor() {
+        super({ kwilProvider: 'doesnt matter' });
+    }
+}
+
+describe('ActionBuilder', () => {
+    let actionBuilder: ActionBuilder;
+    let mockKwil = new TestKwil();
+
+    beforeEach(() => {
+        actionBuilder = ActionBuilderImpl.of(mockKwil);
+        getMock.mockReset();
+        postMock.mockReset();
+        getMock.mockClear();
+        jest.clearAllMocks();
+    });
+
+    describe('of', () => {
+        it('should return an ActionBuilderImpl', () => {
+            const result = ActionBuilderImpl.of(mockKwil);
+            expect(result).toBeInstanceOf(ActionBuilderImpl);
+        });
+    })
+
+    describe('name', () => {
+        it('should set the _name field and return actionBuilder', () => {
+            const result = actionBuilder.name('testName');
+            expect(result).toBe(actionBuilder);
+            expect((actionBuilder as any)._name).toBe('testname');
+        });
+    })
+
+    describe('dbid', () => {
+        it('should set the _dbid field and return actionBuilder', () => {
+            const result = actionBuilder.dbid('testDbid');
+            expect(result).toBe(actionBuilder);
+            expect((actionBuilder as any)._dbid).toBe('testDbid');
+        });
+    });
+
+    describe('signer', () => {
+        it('should set the _signer field and return actionBuilder', () => {
+            const sig = Wallet.createRandom()
+            const result = actionBuilder.signer(sig);
+            expect(result).toBe(actionBuilder);
+            expect((actionBuilder as any)._signer).toBeDefined();
+            expect((actionBuilder as any)._signer).toBe(sig);
+        });
+    });
+
+    describe('concat', () => {
+        it('should take one ActionInput and add it to the _actions field', () => {
+            const actionInput: ActionInput = new ActionInput()
+                .put('test', 'test')
+            ;
+            const result = actionBuilder.concat(actionInput);
+            expect(result).toBe(actionBuilder);
+            expect((actionBuilder as any)._actions).toEqual([actionInput]);
+        });
+
+        it('should take an array of ActionInputs and add them to the _actions field', () => {
+            const actionInput1: ActionInput = new ActionInput()
+                .put('test', 'test')
+            ;
+            const actionInput2: ActionInput = new ActionInput()
+                .put('test', 'test')
+            ;
+            const result = actionBuilder.concat([actionInput1, actionInput2]);
+            expect(result).toBe(actionBuilder);
+            expect((actionBuilder as any)._actions).toEqual([actionInput1, actionInput2]);
+        });
+    });
+
+    describe('buildTx', () => {
+        it('should build a transaction', async () => {
+            const actionInput: ActionInput = new ActionInput()
+                .put('test', 'test')
+
+            getMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    dataset: {
+                        name: 'testName',
+                        dbid: 'testDbid',
+                        tables: "someTables",
+                        actions: [{
+                            name: 'testactionname',
+                            public: true,
+                            mutability: 'view',
+                            auxiliaries: [],
+                            inputs: ['test'],
+                            statements: ['test']
+                        }]
+                    }
+                }
+            });
+
+            const wallet = Wallet.createRandom()
+
+            const mockedAccount = {
+                address: wallet.address,
+                balance: "10000000000000000",
+                nonce: 1
+            }
+
+            getMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    account: mockedAccount
+                }
+            })
+            
+            postMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    price: "100000"
+                }
+            });
+
+            const result = await actionBuilder
+                .name('testactionname')
+                .dbid('testDbid')
+                .signer(wallet)
+                .concat(actionInput)
+                .buildTx();
+
+            expect(result).toBeDefined();
+            expect(result).toBeInstanceOf(Transaction);
+            expect(result.fee).toBe('100000');
+            expect(typeof result.signature.signature_bytes).toBe('string');
+            expect(result.signature.signature_type).toBe(2);
+            expect(result.payload).toBe('eyJhY3Rpb24iOiJ0ZXN0YWN0aW9ubmFtZSIsImRiaWQiOiJ0ZXN0RGJpZCIsInBhcmFtcyI6W3sidGVzdCI6InRlc3QifV19')
+            expect(result.sender).toBe(wallet.address);
+            expect(result.payload_type).toBe(104);
+            expect(result.nonce).toBe(mockedAccount.nonce + 1);
+            expect(result.hash).toBe('cNbUo4v85dSU0ZJDGJwiwXmw7l0UQEbblzGctbihq7UqhCta4ixAvOtfCZK3Bui9');
+        });
+
+        it('should throw error when the db has no actions', async () => {
+            const actionInput: ActionInput = new ActionInput().put('test', 'test');
+        
+            getMock.mockResolvedValueOnce({
+                status: 200,
+                data: {}
+            });
+        
+            const wallet = Wallet.createRandom();
+        
+            await expect(
+                actionBuilder
+                    .name('testactionname')
+                    .dbid('test2')
+                    .signer(wallet)
+                    .concat(actionInput)
+                    .buildTx()
+            ).rejects.toThrow();
+        });
+
+        it("Should throw error when the provided action name does not exist on a schema", async () => {
+            const actionInput = new ActionInput().put('test', 'test');
+
+            getMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    dataset: {
+                        name: 'testName',
+                        dbid: 'testDbid',
+                        tables: "someTables",
+                        actions: [{
+                            name: 'testactionname',
+                            public: true,
+                            mutability: 'view',
+                            auxiliaries: [],
+                            inputs: ['test'],
+                            statements: ['test']
+                        }]
+                    }
+                }
+            });
+
+            const wallet = Wallet.createRandom();
+
+            await expect(
+                actionBuilder
+                    .name('testactionname2')
+                    .dbid('testDbid')
+                    .signer(wallet)
+                    .concat(actionInput)
+                    .buildTx()
+            ).rejects.toThrow();
+        })
+    });
+});

--- a/tests/unitTests/builders/db_builder.test.ts
+++ b/tests/unitTests/builders/db_builder.test.ts
@@ -1,0 +1,88 @@
+import { getMock, postMock } from "../api_client/api-utils";
+import { DBBuilderImpl } from "../../../src/builders/db_builder";
+import { DBBuilder } from "../../../src/core/builders";
+import { Kwil } from "../../../src/client/kwil";
+import { Wallet } from "ethers";
+import { PayloadType, Transaction } from "../../../src/core/tx";
+
+class TestKwil extends Kwil {
+    public constructor() {
+        super({ kwilProvider: 'doesnt matter'})
+    }
+}
+
+describe('DbBuilder', () => {
+    let dbBuilder: DBBuilder;
+    const mockKwil = new TestKwil();
+
+    beforeEach(() => {
+        dbBuilder = DBBuilderImpl.of(mockKwil);
+        getMock.mockReset();
+        postMock.mockReset();
+    });
+
+    describe('of', () => {
+        it('should return a DBBuilderImpl', () => {
+            const result = DBBuilderImpl.of(mockKwil);
+            expect(result).toBeInstanceOf(DBBuilderImpl);
+        });
+    })
+
+    describe('signer', () => {
+        it('should set the _signer field and return a dbBuilder', () => {
+            const sig = Wallet.createRandom();
+            const result = dbBuilder.signer(sig);
+            expect(result).toBe(dbBuilder);
+            expect((dbBuilder as any)._signer).toBe(sig);
+        })
+    })
+
+    describe('payload', () => {
+        it('should set the _payload field and return a dbBuilder', () => {
+            const payload = { test: 'test' };
+            const result = dbBuilder.payload(payload);
+            expect(result).toBe(dbBuilder);
+            expect((dbBuilder as any)._payload).toBe;
+        })
+    })
+
+    describe('buildTx', () => {
+        it('should build a transaction', async () => {
+            const wallet = Wallet.createRandom()
+
+            const mockedAccount = {
+                address: wallet.address,
+                balance: "10000000000000000",
+                nonce: 1
+            }
+
+            getMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    account: mockedAccount
+                }
+            })
+            
+            postMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    price: "100000"
+                }
+            });
+
+            const result: Transaction = await dbBuilder
+                .signer(wallet)
+                .payload({ test: 'test' })
+                .buildTx();
+
+            expect(result).toBeInstanceOf(Transaction);
+            expect(result.hash).toBe('042jEOCmIUkhIH7l/BZd6i6v4PNeu9WhAZvnD1cztaH8o7HJPCjsTppQ9Ov7Yt5X');
+            expect(result.fee).toBe('100000');
+            expect(result.nonce).toBe(mockedAccount.nonce + 1);
+            expect(result.payload).toBe('eyJ0ZXN0IjoidGVzdCJ9');
+            expect(result.sender).toBe(wallet.address);
+            expect(typeof result.signature.signature_bytes).toBe('string');
+            expect(result.signature.signature_type).toBe(2);
+        })
+    })
+})

--- a/tests/unitTests/builders/transaction_builder.test.ts
+++ b/tests/unitTests/builders/transaction_builder.test.ts
@@ -1,0 +1,160 @@
+import { getMock, postMock } from '../api_client/api-utils';
+import { TxnBuilderImpl } from '../../../src/builders/transaction_builder';
+import { TxnBuilder } from '../../../src/core/builders';
+import { Kwil } from '../../../src/client/kwil';
+import { PayloadType, Transaction } from '../../../src/core/tx';
+import { Wallet } from 'ethers';
+
+class TestKwil extends Kwil {
+    constructor() {
+        super({kwilProvider: 'doesnt matter' })
+    }
+}
+
+describe('Transaction Builder', () => {
+    let txBuilder: TxnBuilder;
+    let mockKwil = new TestKwil();
+
+    beforeEach(() => {
+        txBuilder = TxnBuilderImpl.of(mockKwil);
+        getMock.mockReset();
+        postMock.mockReset();
+    });
+
+    describe('of', () => {
+        it('should return a TxnBuilderImpl', () => {
+            const result = TxnBuilderImpl.of(mockKwil);
+            expect(result).toBeInstanceOf(TxnBuilderImpl);
+        });
+    })
+
+    describe('payload', () => {
+        it('should set the payloadand return TxnBuilderImpl', () => {
+            const result = txBuilder.payload({foo: 'bar'});
+            expect(result).toBeInstanceOf(TxnBuilderImpl);
+            expect((result as any)._payload).toBeDefined();
+        });
+    })
+
+    describe('payloadType', () => {
+        it('should set the payloadType and return TxnBuilderImpl', () => {
+            const result = txBuilder.payloadType(PayloadType.DEPLOY_DATABASE);
+            expect(result).toBeInstanceOf(TxnBuilderImpl);
+            expect((result as any)._payloadType).toBe(101);
+        })
+    })
+
+    describe('signer', () => {
+        it('should set the signer and return TxnBuilderImpl', () => {
+            const sig = Wallet.createRandom();
+            const result = txBuilder.signer(sig);
+            expect(result).toBeInstanceOf(TxnBuilderImpl);
+            expect((result as any)._signer).toBe(sig);
+        });
+    });
+
+    describe('build', () => {
+        it('should build a transaction', async () => {
+            const wallet = Wallet.createRandom()
+
+            const mockedAccount = {
+                address: wallet.address,
+                balance: "10000000000000000",
+                nonce: 1
+            }
+
+            getMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    account: mockedAccount
+                }
+            })
+            
+            postMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    price: "100000"
+                }
+            });
+
+            const result = await txBuilder
+                .payload({foo: 'bar'})
+                .payloadType(PayloadType.DEPLOY_DATABASE)
+                .signer(wallet)
+                .build();
+
+            const extRes = {
+                hash: 'kWBaCs+MeotmBuOMSKJFxsDaA2r0yIBmv9ljdMIHRnc8vbVfkY4Hg4uTvYfYJitM',
+                payload_type: 101,
+                payload: 'eyJmb28iOiJiYXIifQ==',
+                fee: '100000',
+                nonce: 2,
+                signature: {
+                  signature_bytes: 'string',
+                  signature_type: 2
+                },
+                sender: wallet.address
+              }
+            expect(result).toBeInstanceOf(Transaction);
+            expect(result.hash).toBe(extRes.hash);
+            expect(result.payload_type).toBe(extRes.payload_type);
+            expect(result.payload).toBe(extRes.payload);
+            expect(result.fee).toBe(extRes.fee);
+            expect(result.nonce).toBe(extRes.nonce);
+            expect(result.signature.signature_type).toEqual(extRes.signature.signature_type);
+            expect(typeof result.signature.signature_bytes).toEqual(extRes.signature.signature_bytes);
+            expect(result.sender).toBe(wallet.address);
+        });
+
+        it('should throw error if account does not exist', async() => {
+            getMock.mockResolvedValueOnce({
+                status: 400,
+                data: {
+                    error: "Account not found!"
+                }
+            })
+
+            const wallet = Wallet.createRandom()
+
+            await expect(
+                txBuilder
+                    .payload({foo: 'bar'})
+                    .payloadType(PayloadType.DEPLOY_DATABASE)
+                    .signer(wallet)
+                    .build()
+            ).rejects.toThrow();
+        })
+
+        it('should throw error if it cannot estimate cost', async () => {
+            const wallet = Wallet.createRandom()
+
+            const mockedAccount = {
+                address: wallet.address,
+                balance: "10000000000000000",
+                nonce: 1
+            }
+
+            getMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    account: mockedAccount
+                }
+            })
+            
+            postMock.mockResolvedValueOnce({
+                status: 400,
+                data: {
+                    error: 'Cannot estimate cost'
+                }
+            });
+
+            await expect(
+                txBuilder
+                    .payload({foo: 'bar'})
+                    .payloadType(PayloadType.DEPLOY_DATABASE)
+                    .signer(wallet)
+                    .build()
+            ).rejects.toThrow();
+        })
+    });
+})

--- a/tests/unitTests/client/intern.test.ts
+++ b/tests/unitTests/client/intern.test.ts
@@ -1,0 +1,26 @@
+import { wrap, unwrap } from "../../../src/client/intern";
+import { Kwil } from "../../../src/client/kwil";
+import Client from "../../../src/api_client/client";
+
+class TestKwil extends Kwil {
+    constructor() {
+        super({ kwilProvider: 'doesnt matter' })
+    }
+}
+
+describe("client/intern", () => {
+
+    const testClient = new Client({ kwilProvider: 'doesnt matter' });
+
+    it('wrap should wrap Kwil client', () => {
+        const kwil = new TestKwil();
+        const wrapped = wrap(kwil, testClient.estimateCost);
+        expect(wrapped).toBe(undefined);
+    })
+
+    it('unwrap should unwrap Kwil client etimate cost method', () => {
+        const kwil = new TestKwil();
+        const unwrapped = unwrap(kwil);
+        expect(typeof unwrapped).toBe('function');
+    });
+});

--- a/tests/unitTests/client/kwil_client.test.ts
+++ b/tests/unitTests/client/kwil_client.test.ts
@@ -1,0 +1,184 @@
+import { getMock, postMock } from "../api_client/api-utils";
+import { Kwil } from "../../../src/client/kwil";
+import { ActionBuilderImpl } from "../../../src/builders/action_builder";
+import { DBBuilderImpl } from "../../../src/builders/db_builder";
+import { PayloadType, Transaction } from "../../../src/core/tx";
+import { DropDBBuilderImpl } from "../../../src/builders/drop_db_builder";
+
+class TestKwil extends Kwil {
+    constructor() {
+        super({kwilProvider: 'doesnt matter'});
+    }
+}
+
+describe('Kwil', () => {
+    let kwil: TestKwil;
+
+    beforeEach(() => {
+        kwil = new TestKwil();
+        getMock.mockReset();
+        postMock.mockReset();
+    });
+
+    describe('getDBID', () => {
+        it('should return the dbid', () => {
+            const address = '0xc89D42189f0450C2b2c3c61f58Ec5d628176A1E7';
+            const dbid = kwil.getDBID(address, 'mydb');
+            expect(dbid).toBe('xcdd04ff7c5e4a939d5365ec9b54cc4aab8c610c415f5f9b33323ae77');
+        });
+    })
+
+    describe('getSchema', () => {
+        it('should return a schema for a given dbid', async () => {
+            getMock.mockResolvedValue({
+                status: 200,
+                data: { dataset: 'mockDataset' }
+            });
+    
+            const result = await kwil.getSchema('somedbid')
+            expect(result.status).toBe(200);
+            expect(result.data).toBe('mockDataset');
+        })
+
+        it('should not have to make a second request if searching for the same dbid', async() => {
+            getMock.mockResolvedValue({
+                status: 200,
+                data: { dataset: 'mockDataset' }
+            });
+    
+            await kwil.getSchema('somedbid');
+            const res = await kwil.getSchema('somedbid');
+            expect(getMock).toHaveBeenCalledTimes(1);
+            expect(res.data).toBe('mockDataset');
+        })
+    })
+
+    describe('getAccount', () => {
+        it('should return account info for a given wallet address', async () => {
+            getMock.mockResolvedValue({
+                status: 200,
+                data: { account: 'mockAccount' }
+            });
+
+            const result = await kwil.getAccount('someaddress');
+            expect(result.status).toBe(200);
+            expect(result.data).toBe('mockAccount');
+        })
+    })
+
+    describe('actionBuilder', () => {
+        it('should return an action builder', () => {
+            const actionBuilder = kwil.actionBuilder();
+            expect(actionBuilder).toBeDefined();
+            expect(actionBuilder).toBeInstanceOf(ActionBuilderImpl)
+        })
+    });
+
+    describe('dbBuilder', () => {
+        it('should return a db builder', () => {
+            const dbBuilder = kwil.dbBuilder();
+            expect(dbBuilder).toBeDefined();
+            expect(dbBuilder).toBeInstanceOf(DBBuilderImpl)
+        });
+    })
+
+    describe('dropDbBuilder', () => {
+        it('should return a db builder', () => {
+            const dbBuilder = kwil.dropDBBuilder();
+            expect(dbBuilder).toBeDefined();
+            expect(dbBuilder).toBeInstanceOf(DropDBBuilderImpl)
+        })
+    })
+
+    describe('broadcast', () => {
+        it('should broadcast a transaction', async () => {
+            const tx = new Transaction({
+                hash: 'mockHash',
+                payload_type: PayloadType.EXECUTE_ACTION,
+                payload: 'mockPayload',
+                fee: 'mockFee',
+                nonce: 1,
+                sender: 'mockSender',
+                signature: {
+                    signature_bytes: 'mockSignatureBytes',
+                    signature_type: 1
+                }
+            })
+
+            postMock.mockResolvedValue({
+                status: 200,
+                data: { receipt: { txHash: '3D/Em+hqmZYG/Zl7+Jfsag0B1hjD/t3Z/42tk2xru8ecmCD14dY4OZ6q11o3PuEP', fee: 'mockFee', body: 'W10=' } }
+            });
+
+            const result = await kwil.broadcast(tx);
+
+            expect(result.status).toBe(200);
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual({
+                txHash: '0xdc3fc49be86a999606fd997bf897ec6a0d01d618c3feddd9ff8dad936c6bbbc79c9820f5e1d638399eaad75a373ee10f',
+                fee: 'mockFee',
+                body: []
+            });
+        })
+    })
+
+    describe('listDatabase', () => {
+        it('should return a list of databases for a given wallet address', async () => {
+            getMock.mockResolvedValue({
+                status: 200,
+                data: { databases: ['db1', 'db2'] }
+            });
+            const result = await kwil.listDatabases('someaddress');
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual(['db1', 'db2']);
+        });
+    })
+
+    describe('ping', () => {
+        it('should ping the kwil server', async () => {
+            getMock.mockResolvedValue({
+                status: 200,
+                data: { message: 'pong' }
+            });
+            const result = await kwil.ping();
+            expect(result.status).toBe(200);
+            expect(result.data).toEqual('pong');
+        })
+    })
+
+    // TODO: need to add mocks for smart contract calls
+    // describe('getFunder', () => {
+    //     it('should return the funder for a given signer', async () => {
+    //         const provider = new JsonRpcProvider(process.env.ETH_PROVIDER)
+    //         const sig = Wallet.createRandom(provider)
+
+    //         getMock.mockResolvedValueOnce({
+    //             status: 200,
+    //             data: { 
+    //                 "chain_code": "2",
+    //                 "provider_address": "0x37Fc1953e4A26007E6Df52f06B5897a998F51f5D",
+    //                 "pool_address": "0xb0a194286A901FeAEA39D2b765247BEd64aD4F41"
+    //             }
+    //         });
+    //         const result = await kwil.getFunder(sig);
+    //         expect(result).toBeInstanceOf(Funder);
+    //     })
+    // })
+
+    describe('selectQuery', () => {
+        it('should return data for a select query', async () => {
+            postMock.mockResolvedValueOnce({
+                status: 200,
+                data: {
+                    result: "W10="
+                }
+            })
+
+            const query = await kwil.selectQuery('dbid', 'query');
+            console.log(query)
+            expect(query).toBeDefined();
+            expect(query.status).toBe(200)
+            expect(query.data).toEqual([])
+        })
+    })
+});

--- a/tests/unitTests/utils/cache.test.ts
+++ b/tests/unitTests/utils/cache.test.ts
@@ -1,0 +1,134 @@
+import { Cache } from '../../../src/utils/cache';
+
+describe('Cache', () => {
+    describe('when set to active', () => {
+        let activeCache: Cache<string> = Cache.active();
+        
+        beforeEach(() => {
+            jest.useFakeTimers();
+            activeCache = Cache.active(100, 1);
+        })
+
+        afterEach(() => {
+            activeCache?.shutdown();
+            jest.clearAllTimers();
+        })
+
+        it('should set a value with a time', () => {
+            activeCache.set('key', 'hello world')
+            const cachedTime = Date.now();
+
+            expect((activeCache as any).cache.get('key').v).toEqual('hello world');
+            expect((activeCache as any).cache.get('key').d).toBeGreaterThan(cachedTime);
+        })
+
+        it('should get a value', () => {
+            activeCache.set('key', 'hello world');
+            const res = activeCache.get('key');
+            expect(res).toEqual('hello world');
+        })
+
+        it('should remove an item from the cache after it is stale', () => {
+            const mockSetInterval = jest.fn(() => 12345) as unknown as jest.MockedFunction<typeof setInterval>;
+            (mockSetInterval.__promisify__ as unknown) = jest.fn();
+
+            global.setInterval = mockSetInterval;
+            activeCache.set('key', 'hello world');
+            const res1 = activeCache.get('key');
+            expect(res1).toEqual('hello world');
+
+            jest.advanceTimersByTime(101 * 1000);
+
+            const res2 = activeCache.get('key');
+            expect(setInterval).toHaveBeenCalledTimes(1);
+            expect(res2).toBe(null);
+        })
+
+        it('should shutdown the cache cleanup', () => {
+            const mockSetInterval = jest.fn(() => 12345) as unknown as jest.MockedFunction<typeof setInterval>;
+            (mockSetInterval.__promisify__ as unknown) = jest.fn();
+
+            global.setInterval = mockSetInterval;
+            global.clearInterval = jest.fn();
+
+
+            activeCache.set('key', 'hello world');
+
+            // advance timers
+            jest.advanceTimersByTime(2 * 1000);
+
+            // At this point, the cleanup interval should be running
+            expect(setInterval).toHaveBeenCalledTimes(1);
+
+            activeCache.shutdown();
+        
+            // Ensure that clearInterval was called to clear the cleanup interval
+            expect(clearInterval).toHaveBeenCalledTimes(1);
+        });  
+    });
+
+    describe('when set to passive', () => {
+        let passiveCache: Cache<string> = Cache.passive();
+        
+        beforeEach(() => {
+            jest.useFakeTimers();
+            passiveCache = Cache.passive(100);
+        })
+
+        afterEach(() => {
+            jest.clearAllTimers();
+        })
+
+        it('should set a value with a time', () => {
+            passiveCache.set('key', 'hello world')
+            const cachedTime = Date.now();
+
+            expect((passiveCache as any).cache.get('key').v).toEqual('hello world');
+            expect((passiveCache as any).cache.get('key').d).toBeGreaterThan(cachedTime);
+        })
+
+        it('should get a value', () => {
+            passiveCache.set('key', 'hello world');
+            const res = passiveCache.get('key');
+            expect(res).toEqual('hello world');
+        });
+
+        it('should remove an item from the cache after it is stale', () => {
+            const mockSetInterval = jest.fn(() => 12345) as unknown as jest.MockedFunction<typeof setInterval>;
+            (mockSetInterval.__promisify__ as unknown) = jest.fn();
+
+            global.setInterval = mockSetInterval;
+            passiveCache.set('key', 'hello world');
+            const res1 = passiveCache.get('key');
+            expect(res1).toEqual('hello world');
+
+            jest.advanceTimersByTime(101 * 1000);
+
+            const res2 = passiveCache.get('key');
+            expect(res2).toBe(null);
+            expect(setInterval).toHaveBeenCalledTimes(0);
+        });
+
+        it('should shutdown the cache cleanup', () => {
+            const mockSetInterval = jest.fn(() => 12345) as unknown as jest.MockedFunction<typeof setInterval>;
+            (mockSetInterval.__promisify__ as unknown) = jest.fn();
+
+            global.setInterval = mockSetInterval;
+            global.clearInterval = jest.fn();
+
+
+            passiveCache.set('key', 'hello world');
+
+            // advance timers
+            jest.advanceTimersByTime(2 * 1000);
+
+            // In passive, setInterval does not run
+            expect(setInterval).toHaveBeenCalledTimes(0);
+
+            passiveCache.shutdown();
+        
+            // clearInterval also does not run
+            expect(clearInterval).toHaveBeenCalledTimes(0);
+        });
+    })
+})


### PR DESCRIPTION
removed the existing map that getSchema responses were stored in and implemented a time-to-live cache. The cache defaults to 10 minutes. The cache time can be set by passing a "cache" property to the config object in the `WebKwil` and `NodeKwil` classes.

fix #8