### PR TITLE
feat(client/kwil.ts): require chainID to be configured in Kwil constr…

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -6,6 +6,41 @@ Note that this SDK must be used with a Kwil Daemon that is running the CometBFT 
 
 ## Breaking Changes
 
+### Chain ID Configuration
+
+In order to prevent users from accidentally broadcasting transactions to the wrong Kwil chain, the Kwil chain ID must now be specified when initializing the Kwil object.
+
+#### Old Version
+
+```javascript
+const kwil = new WebKwil({
+    provider: 'https://kwil.com',
+});
+```
+
+#### New Version
+
+```javascript
+const kwil = new WebKwil({
+    provider: 'https://kwil.com',
+    chainId: 'your_chain_id'
+});
+```
+
+You can check the chain ID of your Kwil chain by calling `kwil.chainInfo()`.
+
+```javascript
+const res = await kwil.chainInfo()
+
+/*
+    res.data = {
+        chain_id: "your_chain_id",
+        height: "latest_block_height",
+        hash: "latest_block_hash"
+    }
+*/
+```
+
 ### Wallet Address Identifiers -> Public Keys
 
 Because the newest version of Kwil suports both Secp256k1 Signatures and ED25519 Signatures, accounts and databases are now associated with public keys, not just ethereum wallet address.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ import { WebKwil } from '@kwilteam/kwil-js';
 const provider = new BrowserProvider(window.ethereum)
 
 const kwil = new WebKwil({
-    kwilProvider: "kwil_provider_endpoint"
+    kwilProvider: "kwil_provider_endpoint",
+    chainId: "your_kwil_chain_id"
 });
 ```
 
@@ -36,6 +37,7 @@ const wallet = new Wallet("my_ethereum_private_key")
 
 const kwil = new kwiljs.NodeKwil({
     kwilProvider: "kwil_provider_endpoint",
+    chainId: "your_kwil_chain_id"
 });
 ```
 
@@ -207,7 +209,23 @@ const res = await kwil.selectQuery(dbid, "SELECT * FROM users")
 */
 ```
 
-## Database Info
+## Network Info
+
+### ChainID and Status
+
+To verify that you are using the correct chainID, as well as the latest block height and block hash on your chain, you can call the `.chainInfo()` method.
+
+``` javascript
+const res = await kwil.chainInfo()
+
+/*
+    res.data = {
+        chainId: "your_chain_id",
+        blockHeight: "latest_block_height",
+        blockHash: "latest_block_hash"
+    }
+*/
+```
 
 ### Listing Databases
 

--- a/src/api_client/api.ts
+++ b/src/api_client/api.ts
@@ -1,5 +1,5 @@
-import Axios, { AxiosResponse, AxiosRequestConfig, AxiosInstance } from "axios";
-import {Config} from "./config";
+import Axios, { AxiosResponse, AxiosRequestConfig, AxiosInstance } from 'axios';
+import { ApiConfig } from './config';
 /*
     Based off https://github.com/ArweaveTeam/arweave-js/blob/189beeba86eb58605be42cfe9d9bd53e35e3ea11/src/common/lib/api.ts#L3
     Since the Arweave SDK has a great typescript API, I've based this off of that.
@@ -13,90 +13,88 @@ import {Config} from "./config";
 */
 
 export abstract class Api {
-    //private readonly METHOD_GET = 'GET';
-    //private readonly METHOD_POST = 'POST';
-    private readonly host: string;
+  //private readonly METHOD_GET = 'GET';
+  //private readonly METHOD_POST = 'POST';
+  private readonly host: string;
 
-    public config!: Config;
-    protected constructor(host: string, opts: Config) {
-        this.config = this.mergeDefaults(opts);
-        this.host = host;
+  public config!: ApiConfig;
+  protected constructor(host: string, opts: ApiConfig) {
+    this.config = this.mergeDefaults(opts);
+    this.host = host;
+  }
+
+  private mergeDefaults(opts: ApiConfig): ApiConfig {
+    return {
+      kwilProvider: opts.kwilProvider || 'https://provider.kwil.com', // these aren't actually used here but are required by the interface
+      timeout: opts.timeout || 10000,
+      apiKey: opts.apiKey || '',
+      logging: opts.logging || false,
+      logger: opts.logger || console.log,
+      network: opts.network,
+      cache: opts.cache || 10 * 60,
+    };
+  }
+
+  protected async get<T = any>(
+    endpoint: string,
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<T>> {
+    try {
+      return await this.request().get<T>(endpoint, config);
+    } catch (error: any) {
+      if (error.response && error.response.status) {
+        return error.response;
+      }
+
+      throw error;
     }
+  }
 
-    private mergeDefaults(opts: Config): Config {
-        return {
-            kwilProvider: opts.kwilProvider || 'https://provider.kwil.com', // these aren't actually used here but are required by the interface
-            timeout: opts.timeout || 10000,
-            apiKey: opts.apiKey || '',
-            logging: opts.logging || false,
-            logger: opts.logger || console.log,
-            network: opts.network,
-            cache: opts.cache || 10 * 60,
-        };
+  protected async post<T = any>(
+    endpoint: string,
+    body: Buffer | string | object,
+    config?: AxiosRequestConfig
+  ): Promise<AxiosResponse<T>> {
+    try {
+      return await this.request().post(endpoint, body, config);
+    } catch (error: any) {
+      if (error.response && error.response.status) {
+        return error.response;
+      }
+
+      throw error;
     }
+  }
 
-    protected async get<T = any>(
-        endpoint: string,
-        config?: AxiosRequestConfig
-      ): Promise<AxiosResponse<T>> {
-        try {
-          return await this.request().get<T>(endpoint, config);
-        } catch (error: any) {
-          if (error.response && error.response.status) {
-            return error.response;
-          }
-    
-          throw error;
-        }
-      }
+  /**
+   * Get an AxiosInstance with the base configuration setup to fire off
+   * a request to the network.
+   */
+  protected request(): AxiosInstance {
+    const headers: any = {
+      'X-Api-Key': this.config.apiKey,
+    };
+    if (this.config.network) {
+      headers['x-network'] = this.config.network;
+    }
+    let instance = Axios.create({
+      baseURL: this.host,
+      timeout: this.config.timeout,
+      maxContentLength: 1024 * 1024 * 512,
+      headers,
+    });
 
-    protected async post<T = any>(
-        endpoint: string,
-        body: Buffer | string | object,
-        config?: AxiosRequestConfig
-      ): Promise<AxiosResponse<T>> {
-        try {
-          return await this.request().post(endpoint, body, config);
-        } catch (error: any) {
-          if (error.response && error.response.status) {
-            return error.response;
-          }
-    
-          throw error;
-        }
-      }
-    
-      /**
-       * Get an AxiosInstance with the base configuration setup to fire off
-       * a request to the network.
-       */
-      protected request(): AxiosInstance {
-        const headers: any = {
-          "X-Api-Key": this.config.apiKey
-        };
-        if (this.config.network) {
-          headers["x-network"] = this.config.network;
-        }
-        let instance = Axios.create({
-          baseURL: this.host,
-          timeout: this.config.timeout,
-          maxContentLength: 1024 * 1024 * 512,
-          headers,
-        });
-    
-        if (this.config.logging) {
-          instance.interceptors.request.use((request) => {
-            this.config.logger!(`Requesting: ${request.baseURL}${request.url}`);
-            return request;
-          });
-    
-          instance.interceptors.response.use((response) => {
-            this.config.logger!(
-              `Response:   ${response.config.url} - ${response.status}`
-            );
-            return response;
-          });
-        }
-        return instance;
-      }
+    if (this.config.logging) {
+      instance.interceptors.request.use((request) => {
+        this.config.logger!(`Requesting: ${request.baseURL}${request.url}`);
+        return request;
+      });
+
+      instance.interceptors.response.use((response) => {
+        this.config.logger!(`Response:   ${response.config.url} - ${response.status}`);
+        return response;
+      });
+    }
+    return instance;
+  }
 }

--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -1,213 +1,231 @@
-import { base64ToBytes, bytesToBase64 } from "../utils/base64";
-import { Account } from "../core/account";
-import { Database, SelectQuery } from "../core/database";
-import { BaseTransaction, Transaction, TxReceipt } from "../core/tx";
-import { Api } from "./api";
-import { Config } from "./config";
+import { base64ToBytes, bytesToBase64 } from '../utils/base64';
+import { Account, ChainInfo } from '../core/network';
+import { Database, SelectQuery } from '../core/database';
+import { Transaction, TxReceipt } from '../core/tx';
+import { Api } from './api';
+import { ApiConfig } from './config';
 import {
-    BroadcastReq,
-    BroadcastRes,
-    CallRes,
-    EstimateCostReq,
-    EstimateCostRes,
-    GenericResponse,
-    GetAccountResponse, GetSchemaResponse,
-    ListDatabasesResponse, PongRes, SelectRes, TxQueryReq, TxQueryRes
-} from "../core/resreq";
-import { base64UrlEncode, bytesToHex, hexToBytes } from "../utils/serial";
-import { TxInfoReceipt } from "../core/txQuery";
-import { Message, MsgData, MsgReceipt } from "../core/message";
-import { kwilDecode } from "../utils/rlp";
-import { BytesEncodingStatus } from "../core/enums";
+  BroadcastReq,
+  BroadcastRes,
+  CallRes,
+  ChainInfoRes,
+  EstimateCostReq,
+  EstimateCostRes,
+  GenericResponse,
+  GetAccountResponse,
+  GetSchemaResponse,
+  ListDatabasesResponse,
+  PongRes,
+  SelectRes,
+  TxQueryReq,
+  TxQueryRes,
+} from '../core/resreq';
+import { base64UrlEncode, bytesToHex, hexToBytes } from '../utils/serial';
+import { TxInfoReceipt } from '../core/txQuery';
+import { Message, MsgData, MsgReceipt } from '../core/message';
+import { kwilDecode } from '../utils/rlp';
+import { BytesEncodingStatus } from '../core/enums';
 
 export default class Client extends Api {
-    constructor(opts: Config) {
-        super(opts.kwilProvider, opts);
-    }
+  constructor(opts: ApiConfig) {
+    super(opts.kwilProvider, opts);
+  }
 
-    public async getSchema(dbid: string): Promise<GenericResponse<Database>> {
-        const res = await super.get<GetSchemaResponse>(`/api/v1/databases/${dbid}/schema`);
-        checkRes(res);
+  public async getSchema(dbid: string): Promise<GenericResponse<Database>> {
+    const res = await super.get<GetSchemaResponse>(`/api/v1/databases/${dbid}/schema`);
+    checkRes(res);
 
-        let schema: Database = {
-            name: '',
-            owner: new Uint8Array(),
-            tables: [],
-            actions: [],
-            extensions: []
-        }
+    let schema: Database = {
+      name: '',
+      owner: new Uint8Array(),
+      tables: [],
+      actions: [],
+      extensions: [],
+    };
 
-        if (res.data) {
-            schema = {
-                name: res.data.schema.name,
-                owner: base64ToBytes(res.data.schema.owner),
-                tables: res.data.schema.tables,
-                actions: res.data.schema.actions,
-                extensions: res.data.schema.extensions
-            }
-        }
-
-        return {
-            status: res.status,
-            data: schema
-        }
-    }
-
-    public async getAccount(owner: Uint8Array): Promise<GenericResponse<Account>> {
-        const urlSafeB64 = base64UrlEncode(bytesToBase64(owner));
-        const res = await super.get<GetAccountResponse>(`/api/v1/accounts/${urlSafeB64}`);
-        checkRes(res);
-
-        let acct: Account = {
-            balance: '',
-            public_key: new Uint8Array(),
-            nonce: '',
-
-        };
-
-        if (res.data) {
-            acct.balance = res.data.account.balance;
-            acct.public_key = base64ToBytes(res.data.account.public_key as string);
-            acct.nonce = res.data.account.nonce;
-        }
-
-        return {
-            status: res.status,
-            data: acct
-        }
-    }
-
-    public async listDatabases(owner: Uint8Array): Promise<GenericResponse<string[]>> {
-        const urlSafeB64 = base64UrlEncode(bytesToBase64(owner));
-        const res = await super.get<ListDatabasesResponse>(`/api/v1/${urlSafeB64}/databases`);
-        return checkRes(res, r => r.databases);
-    }
-
-    public async estimateCost(tx: Transaction): Promise<GenericResponse<string>> {
-        let req: EstimateCostReq = {tx: tx.txData}
-
-        const res = await super.post<EstimateCostRes>(`/api/v1/estimate_price`, req);
-        return checkRes(res, r => r.price);
-    }
-
-    public async broadcast(tx: Transaction): Promise<GenericResponse<TxReceipt>> {
-        if (!tx.isSigned()) {
-            throw new Error('Tx must be signed before broadcasting.');
-        }
-
-        let req: BroadcastReq = {tx: tx.txData}
-        const res = await super.post<BroadcastRes>(`/api/v1/broadcast`, req);
-        checkRes(res);
-
-        let body = {
-            tx_hash: ''
-        };
-
-        if (res.data.tx_hash) {
-            const bytes = res.data.tx_hash;
-            body.tx_hash = bytesToHex(base64ToBytes(bytes))
-        }
-
-        //TODO: Should we always be returning body, regardless of 
-        return {
-            status: res.status,
-            data: body
-        }
-    }
-
-    public async ping(): Promise<GenericResponse<string>> {
-        const res = await super.get<PongRes>(`/api/v1/ping`);
-        return checkRes(res, r => r.message);
-    }
-
-    public async selectQuery(query: SelectQuery): Promise<GenericResponse<string>> {
-        const res = await super.post<SelectRes>(`/api/v1/query`, query)
-        return checkRes(res, r => r.result);
-    }
-
-    public async txInfo(tx_hash: string): Promise<GenericResponse<TxInfoReceipt>> {
-        tx_hash = bytesToBase64(hexToBytes(tx_hash));
-        const req: TxQueryReq = { tx_hash }
-
-        const res = await super.post<TxQueryRes>(`/api/v1/tx_query`, req)
-        checkRes(res)
-
-        let body;
-
-        if(res.data.hash && res.data.height && res.data.tx && res.data.tx_result) {
-            body = {
-                hash: bytesToHex(base64ToBytes(res.data.hash)),
-                height: res.data.height,
-                tx: {
-                    body: {
-                        payload: kwilDecode(base64ToBytes(res.data.tx.body.payload as string)),
-                        payload_type: res.data.tx.body.payload_type,
-                        fee: res.data.tx.body.fee ? BigInt(res.data.tx.body.fee) : null,
-                        nonce: res.data.tx.body.nonce,
-                        salt: base64ToBytes(res.data.tx.body.salt as string),
-                        description: res.data.tx.body.description
-                    },
-                    signature: {
-                        signature_bytes: base64ToBytes(res.data.tx.signature.signature_bytes as string),
-                        signature_type: res.data.tx.signature.signature_type,
-                    },
-                    sender: (base64ToBytes(res.data.tx.sender as string)),
-                    serialization: res.data.tx.serialization
-                },
-                tx_result: res.data.tx_result
-            };
-        }
-        
-        return {
-            status: res.status,
-            data: body
-        }
-    }
-    
-    public async call(msg: Message): Promise<GenericResponse<MsgReceipt>> {
-        let req: MsgData<BytesEncodingStatus.BASE64_ENCODED> = {
-            body: msg.body,
-            sender: msg.sender,
-            signature: msg.signature,
-            serialization: msg.serialization
-        }
-
-        const res = await super.post<CallRes>(`/api/v1/call`, req);
-        checkRes(res);
-
-        let result: any = null;
-
-        if (res.data.result) {
-            const uint8 = new Uint8Array(base64ToBytes(res.data.result));
-            const decoder = new TextDecoder('utf-8');
-            const jsonString = decoder.decode(uint8);
-            result = JSON.parse(jsonString);
-        }
-
-        const cleanReceipt: MsgReceipt = !result ? {
-            result: null
-        } : {
-            result: result
-        };
-
-        return {
-            status: res.status,
-            data: cleanReceipt
-        };
-    }
-}
-
-function checkRes<T, R>(res: GenericResponse<T>, selector?: (r: T) => R | undefined): GenericResponse<R> {
-    if (res.status != 200 || !res.data) {
-        throw new Error(JSON.stringify(res.data) || 'An unknown error has occurred.  Please check your network connection.');
-    }
-
-    if (!selector) {
-        return { status: res.status, data: undefined };
+    if (res.data) {
+      schema = {
+        name: res.data.schema.name,
+        owner: base64ToBytes(res.data.schema.owner),
+        tables: res.data.schema.tables,
+        actions: res.data.schema.actions,
+        extensions: res.data.schema.extensions,
+      };
     }
 
     return {
-        status: res.status,
-        data: selector(res.data)
+      status: res.status,
+      data: schema,
+    };
+  }
+
+  public async getAccount(owner: Uint8Array): Promise<GenericResponse<Account>> {
+    const urlSafeB64 = base64UrlEncode(bytesToBase64(owner));
+    const res = await super.get<GetAccountResponse>(`/api/v1/accounts/${urlSafeB64}`);
+    checkRes(res);
+
+    let acct: Account = {
+      balance: '',
+      public_key: new Uint8Array(),
+      nonce: '',
+    };
+
+    if (res.data) {
+      acct.balance = res.data.account.balance;
+      acct.public_key = base64ToBytes(res.data.account.public_key as string);
+      acct.nonce = res.data.account.nonce;
     }
+
+    return {
+      status: res.status,
+      data: acct,
+    };
+  }
+
+  public async listDatabases(owner: Uint8Array): Promise<GenericResponse<string[]>> {
+    const urlSafeB64 = base64UrlEncode(bytesToBase64(owner));
+    const res = await super.get<ListDatabasesResponse>(`/api/v1/${urlSafeB64}/databases`);
+    return checkRes(res, (r) => r.databases);
+  }
+
+  public async estimateCost(tx: Transaction): Promise<GenericResponse<string>> {
+    let req: EstimateCostReq = { tx: tx.txData };
+
+    const res = await super.post<EstimateCostRes>(`/api/v1/estimate_price`, req);
+    return checkRes(res, (r) => r.price);
+  }
+
+  public async broadcast(tx: Transaction): Promise<GenericResponse<TxReceipt>> {
+    if (!tx.isSigned()) {
+      throw new Error('Tx must be signed before broadcasting.');
+    }
+
+    let req: BroadcastReq = { tx: tx.txData };
+    const res = await super.post<BroadcastRes>(`/api/v1/broadcast`, req);
+    checkRes(res);
+
+    let body = {
+      tx_hash: '',
+    };
+
+    if (res.data.tx_hash) {
+      const bytes = res.data.tx_hash;
+      body.tx_hash = bytesToHex(base64ToBytes(bytes));
+    }
+
+    //TODO: Should we always be returning body, regardless of
+    return {
+      status: res.status,
+      data: body,
+    };
+  }
+
+  public async ping(): Promise<GenericResponse<string>> {
+    const res = await super.get<PongRes>(`/api/v1/ping`);
+    return checkRes(res, (r) => r.message);
+  }
+
+  public async chainInfo(): Promise<GenericResponse<ChainInfo>> {
+    const res = await super.get<ChainInfoRes>(`/api/v1/chain_info`);
+    return checkRes(res, (r) => r);
+  }
+
+  public async selectQuery(query: SelectQuery): Promise<GenericResponse<string>> {
+    const res = await super.post<SelectRes>(`/api/v1/query`, query);
+    return checkRes(res, (r) => r.result);
+  }
+
+  public async txInfo(tx_hash: string): Promise<GenericResponse<TxInfoReceipt>> {
+    tx_hash = bytesToBase64(hexToBytes(tx_hash));
+    const req: TxQueryReq = { tx_hash };
+
+    const res = await super.post<TxQueryRes>(`/api/v1/tx_query`, req);
+    checkRes(res);
+
+    let body;
+
+    if (res.data.hash && res.data.height && res.data.tx && res.data.tx_result) {
+      body = {
+        hash: bytesToHex(base64ToBytes(res.data.hash)),
+        height: res.data.height,
+        tx: {
+          body: {
+            payload: kwilDecode(base64ToBytes(res.data.tx.body.payload as string)),
+            payload_type: res.data.tx.body.payload_type,
+            fee: res.data.tx.body.fee ? BigInt(res.data.tx.body.fee) : null,
+            nonce: res.data.tx.body.nonce,
+            chain_id: res.data.tx.body.chain_id,
+            description: res.data.tx.body.description,
+          },
+          signature: {
+            signature_bytes: base64ToBytes(res.data.tx.signature.signature_bytes as string),
+            signature_type: res.data.tx.signature.signature_type,
+          },
+          sender: base64ToBytes(res.data.tx.sender as string),
+          serialization: res.data.tx.serialization,
+        },
+        tx_result: res.data.tx_result,
+      };
+    }
+
+    return {
+      status: res.status,
+      data: body,
+    };
+  }
+
+  public async call(msg: Message): Promise<GenericResponse<MsgReceipt>> {
+    let req: MsgData<BytesEncodingStatus.BASE64_ENCODED> = {
+      body: msg.body,
+      sender: msg.sender,
+      signature: msg.signature,
+      serialization: msg.serialization,
+    };
+
+    const res = await super.post<CallRes>(`/api/v1/call`, req);
+    checkRes(res);
+
+    let result: any = null;
+
+    if (res.data.result) {
+      const uint8 = new Uint8Array(base64ToBytes(res.data.result));
+      const decoder = new TextDecoder('utf-8');
+      const jsonString = decoder.decode(uint8);
+      result = JSON.parse(jsonString);
+    }
+
+    const cleanReceipt: MsgReceipt = !result
+      ? {
+          result: null,
+        }
+      : {
+          result: result,
+        };
+
+    return {
+      status: res.status,
+      data: cleanReceipt,
+    };
+  }
+}
+
+function checkRes<T, R>(
+  res: GenericResponse<T>,
+  selector?: (r: T) => R | undefined
+): GenericResponse<R> {
+  if (res.status != 200 || !res.data) {
+    throw new Error(
+      JSON.stringify(res.data) ||
+        'An unknown error has occurred.  Please check your network connection.'
+    );
+  }
+
+  if (!selector) {
+    return { status: res.status, data: undefined };
+  }
+
+  return {
+    status: res.status,
+    data: selector(res.data),
+  };
 }

--- a/src/api_client/config.ts
+++ b/src/api_client/config.ts
@@ -1,6 +1,6 @@
 // config for api
 
-type seconds = number
+type seconds = number;
 
 /**
  * @typedef {Object} Config
@@ -12,12 +12,18 @@ type seconds = number
  * @property {string} [network] - network to use (mainnet, testnet, etc.)
  * @property {number} [cache] - Time to live cache in seconds. Only getSchema requests are cached. Default is 10 minutes.
  */
-export interface Config {
-    kwilProvider: string;
-    timeout?: number;
-    apiKey?: string;
-    logging?: boolean;
-    logger?: Function;
-    network?: string;
-    cache?: seconds;
+export interface ApiConfig {
+  kwilProvider: string;
+  timeout?: number;
+  apiKey?: string;
+  logging?: boolean;
+  logger?: Function;
+  network?: string;
+  cache?: seconds;
 }
+
+export interface NetworkConfig {
+    chainId: string;
+}
+
+export type Config = ApiConfig & NetworkConfig;

--- a/src/builders/action_builder.ts
+++ b/src/builders/action_builder.ts
@@ -1,21 +1,21 @@
-import { Transaction } from "../core/tx";
-import { objects } from "../utils/objects";
-import { HexString, Nillable, NonNil, Promisy } from "../utils/types";
-import { Kwil } from "../client/kwil";
-import { ActionBuilder, SignerSupplier, PayloadBuilder } from "../core/builders";
-import { PayloadBuilderImpl } from "./payload_builder";
-import { ActionInput } from "../core/action";
-import { ActionSchema } from "../core/database";
-import { PayloadType, ValueType } from "../core/enums";
-import { AnySignatureType, SignatureType, getSignatureType } from "../core/signature";
-import { UnencodedActionPayload } from "../core/payload";
-import { Message } from "../core/message";
+import { Transaction } from '../core/tx';
+import { objects } from '../utils/objects';
+import { HexString, Nillable, NonNil, Promisy } from '../utils/types';
+import { Kwil } from '../client/kwil';
+import { ActionBuilder, SignerSupplier, PayloadBuilder } from '../core/builders';
+import { PayloadBuilderImpl } from './payload_builder';
+import { ActionInput } from '../core/action';
+import { ActionSchema } from '../core/database';
+import { PayloadType, ValueType } from '../core/enums';
+import { AnySignatureType, SignatureType, getSignatureType } from '../core/signature';
+import { UnencodedActionPayload } from '../core/payload';
+import { Message } from '../core/message';
 
 interface CheckSchema {
-    dbid: string;
-    name: string;
-    actionSchema: ActionSchema;
-    preparedActions: ValueType[][] | []
+  dbid: string;
+  name: string;
+  actionSchema: ActionSchema;
+  preparedActions: ValueType[][] | [];
 }
 
 const TXN_BUILD_IN_PROGRESS: ActionInput[] = [];
@@ -25,423 +25,487 @@ const TXN_BUILD_IN_PROGRESS: ActionInput[] = [];
  */
 
 export class ActionBuilderImpl implements ActionBuilder {
-    private readonly client: Kwil;
-    private _signer: Nillable<SignerSupplier> = null;
-    private _publicKey: Nillable<HexString | Uint8Array> = null;
-    private _actions: ActionInput[] = [];
-    private _signatureType: Nillable<AnySignatureType>;
-    private _name: Nillable<string>;
-    private _dbid: Nillable<string>;
-    private _description: Nillable<string> = null;
+  private readonly client: Kwil;
+  private _signer: Nillable<SignerSupplier> = null;
+  private _publicKey: Nillable<HexString | Uint8Array> = null;
+  private _actions: ActionInput[] = [];
+  private _signatureType: Nillable<AnySignatureType>;
+  private _name: Nillable<string>;
+  private _dbid: Nillable<string>;
+  private _chainId: Nillable<string>;
+  private _description: Nillable<string> = null;
 
-    /**
-     * Initializes a new `ActionBuilder` instance.
-     * 
-     * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
-     * @returns {ActionBuilder} A new `ActionBuilder` instance.
-     */
-    private constructor(client: Kwil) {
-        this.client = objects.requireNonNil(client, "client cannot be null or undefined. Please pass a valid Kwil client. This is an internal error, please create an issue.");
+  /**
+   * Initializes a new `ActionBuilder` instance.
+   *
+   * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
+   * @returns {ActionBuilder} A new `ActionBuilder` instance.
+   */
+  private constructor(client: Kwil) {
+    this.client = objects.requireNonNil(
+      client,
+      'client cannot be null or undefined. Please pass a valid Kwil client. This is an internal error, please create an issue.'
+    );
+  }
+
+  /**
+   * Creates a new `ActionBuilder` instance.
+   *
+   * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
+   * @returns {ActionBuilder} A new `ActionBuilder` instance.
+   */
+  public static of(client: NonNil<Kwil>): NonNil<ActionBuilder> {
+    return new ActionBuilderImpl(client);
+  }
+
+  /**
+   * Specifies the name of the action to be executed.
+   *
+   * @param {string} actionName - The name of the action to be executed.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the action name is null or undefined.
+   */
+  name(actionName: string): NonNil<ActionBuilder> {
+    this.assertNotBuilding();
+
+    // throw runtime error if action name is null or undefined
+    this._name = objects.requireNonNil(
+      actionName.toLowerCase(),
+      'action name cannot be null or undefined. please specify the action name you wish to execute.'
+    );
+    return this;
+  }
+
+  /**
+   * Specifies the database identifier (DBID) of the database that contains the action to be executed.
+   *
+   * @param {string} dbid - The database identifier.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the dbid is null or undefined.
+   */
+  dbid(dbid: string): NonNil<ActionBuilder> {
+    this.assertNotBuilding();
+
+    // throw runtime error if dbid is null or undefined
+    this._dbid = objects.requireNonNil(
+      dbid,
+      'dbid cannot be null or undefined. please specify the dbid of the database you wish to execute an action on.'
+    );
+    return this;
+  }
+
+  /**
+   * Specifies the signer for the action operation.
+   *
+   * @param {SignerSupplier} signer - The signer for the database operation. This can be a signer from Ethers v5 or Ethers v6 or a custom signer function of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
+   * @param {AnySignatureType} signatureType - The signature type for the database operation. This can be a `SignatureType` enum value or a string for a network-specific signature type. Ethers v5 and Ethers v6 signers will have the signature type inferred from the signer.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the signer is null or undefined.
+   * @throws Will throw an error if the signature type is null or undefined.
+   * @throws Will throw an error if it cannot infer the signature type from the signer.
+   */
+  signer(signer: SignerSupplier, signatureType?: AnySignatureType): NonNil<ActionBuilder> {
+    this.assertNotBuilding();
+
+    // throw runtime error if signer is null or undefined
+    this._signer = objects.requireNonNil(
+      signer,
+      'no signer provided. please specify a signing function or pass an Ethers signer in the KwilSigner.'
+    );
+
+    if (!signatureType) {
+      // infer signature type from signer
+      this._signatureType = getSignatureType(signer);
+
+      // throw runtime error if signature type could not be inferred
+      if (this._signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
+        throw new Error(
+          'Could not determine signature type from signer. Please specify a signature type in the KwilSigner.'
+        );
+      }
+      return this;
     }
 
-    /**
-     * Creates a new `ActionBuilder` instance.
-     * 
-     * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
-     * @returns {ActionBuilder} A new `ActionBuilder` instance.
-     */
-    public static of(client: NonNil<Kwil>): NonNil<ActionBuilder> {
-        return new ActionBuilderImpl(client);
+    // throw runtime error if signature type is null or undefined
+    this._signatureType = objects.requireNonNil(
+      signatureType,
+      'signature type cannot be null or undefined. please specify signature type.'
+    );
+
+    return this;
+  }
+
+  /**
+   * Specifies the public key of the wallet signing for the database operation.
+   *
+   * @param {HexString | Uint8Array} publicKey - The public key of the wallet signing for the database operation.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the public key is null or undefined.
+   */
+  publicKey(publicKey: HexString | Uint8Array): NonNil<ActionBuilder> {
+    this.assertNotBuilding();
+
+    // throw runtime error if public key is null or undefined
+    this._publicKey = objects.requireNonNil(publicKey, 'public key cannot be null or undefined.');
+    return this;
+  }
+
+  /**
+   * Specifies the description to be included in the message that is signed.
+   *
+   * @param {string} description - The description to be included in the message that is signed.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the description is null or undefined.
+   */
+  description(description: string): ActionBuilder {
+    this.assertNotBuilding();
+
+    // throw runtime error if description is null or undefined
+    this._description = objects.requireNonNil(
+      description,
+      'description cannot be null or undefined.'
+    );
+    return this;
+  }
+
+  /**
+   * Adds actionInputs to the list of inputs to be executed in the action.
+   *
+   * @param {ActionInput | ActionInput[]} actions - The actions to add. This should be from the `ActionInput` class.
+   * @returns The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the action is null or undefined.
+   */
+  concat(actions: ActionInput[] | ActionInput): NonNil<ActionBuilder> {
+    this.assertNotBuilding();
+
+    // if actions is not an array, convert it to an array
+    if (!Array.isArray(actions)) {
+      actions = [actions];
     }
 
-    /**
-     * Specifies the name of the action to be executed.
-     * 
-     * @param {string} actionName - The name of the action to be executed.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the action name is null or undefined.
-     */
-    name(actionName: string): NonNil<ActionBuilder> {
-        this.assertNotBuilding();
-
-        // throw runtime error if action name is null or undefined
-        this._name = objects.requireNonNil(actionName.toLowerCase(), 'action name cannot be null or undefined. please specify the action name you wish to execute.');
-        return this;
+    // loop over array of actions and add them to the list of actions
+    for (const action of actions) {
+      // push action into array and throw runtime error if action is null or undefined
+      this._actions.push(
+        objects.requireNonNil(
+          action,
+          'action cannot be null or undefined. Please pass a valid ActionInput object.'
+        )
+      );
     }
 
-    /**
-     * Specifies the database identifier (DBID) of the database that contains the action to be executed.
-     * 
-     * @param {string} dbid - The database identifier.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the dbid is null or undefined.
-     */
-    dbid(dbid: string): NonNil<ActionBuilder> {
-        this.assertNotBuilding();
+    return this;
+  }
 
-        // throw runtime error if dbid is null or undefined
-        this._dbid = objects.requireNonNil(dbid, 'dbid cannot be null or undefined. please specify the dbid of the database you wish to execute an action on.');
-        return this;
+  /**
+   * Specifies the chain ID for the network being used.
+   *
+   * @param {string} chainId - The chain ID for the network being used.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   */
+  chainId(chainId: string): NonNil<ActionBuilder> {
+    this._chainId = objects.requireNonNil(chainId, 'chain ID cannot be null or undefined.');
+    return this;
+  }
+
+  /**
+   * Builds a transaction. This will call the kwil network to retrieve the schema and the signer's account.
+   *
+   * @returns {Promise<Transaction>} - A promise that resolves to a Transaction object. This transaction can be broadcasted to the Kwil network with the `kwil.broadcast()` api.
+   * @throws Will throw an error if the action is being built or if there's an issue with the schema or account retrieval.
+   * @throws Will throw an error if the action is not a update action.
+   */
+  async buildTx(): Promise<Transaction> {
+    this.assertNotBuilding();
+
+    // cache the action
+    const cached = this._actions;
+
+    // set the actions to a special value to indicate that the transaction is being built
+    this._actions = TXN_BUILD_IN_PROGRESS;
+
+    return await this
+      // build the transaction
+      .dobuildTx(cached)
+      // set the actions back to the cached value, signaling that the transaction is no longer being built
+      .finally(() => (this._actions = cached));
+  }
+
+  /**
+   * Builds the message structure for view actions. This can be provided to the `kwil.call()` api.
+   *
+   * @returns {Promise<Message>} - A message object that can be sent to the Kwil network.
+   * @throws Will throw an error if the action is being built or if there's an issue with the schema or account retrieval.
+   * @throws Will throw an error if the action is not a view action.
+   */
+  async buildMsg(): Promise<Message> {
+    this.assertNotBuilding();
+
+    // cache the action
+    const cached = this._actions;
+
+    // set the actions to a special value to indicate that the message is being built
+    this._actions = TXN_BUILD_IN_PROGRESS;
+
+    return await this
+      // build the message
+      .doBuildMsg(cached)
+      // set the actions back to the cached value, signaling that the message is no longer being built
+      .finally(() => (this._actions = cached));
+  }
+
+  /**
+   * Executes all the required logic in the TxnBuildImpl class to build a transaction.
+   *
+   * @param {ActionInput[]} actions - The actions to be executed.
+   * @returns {Transaction} A transaction object that can be broadcasted to the Kwil network.
+   * @throws Will throw an error if there's an issue with the schema or account retrieval & validation.
+   */
+  private async dobuildTx(actions: ActionInput[]): Promise<Transaction> {
+    // retrieve the schema and run validations
+    const { dbid, name, preparedActions, actionSchema } = await this.checkSchema(actions);
+
+    // throw runtime error if signer is null or undefined
+    const signer = objects.requireNonNil(
+      this._signer,
+      'signer is required to build a transaction.'
+    );
+
+    // throw runtime error if chainId is not provided
+    const chainId = objects.requireNonNil(
+      this._chainId,
+      'chain ID is required to build a transaction.'
+    );
+
+    // resolve the public key and throw a runtime error if it is null or undefined
+    const publicKey = await Promisy.resolveOrReject(
+      this._publicKey,
+      'public key is required to build a transaction.'
+    );
+
+    // resolve the signature type and throw a runtime error if it is null or undefined
+    const signatureType = await Promisy.resolveOrReject(
+      this._signatureType,
+      'signature type is required to build a transaction.'
+    );
+
+    // throw runtime error if action is a view action. view actions require a different payload structure than transactions.
+    if (actionSchema.mutability === 'view') {
+      throw new Error(`Action ${name} is a 'view' action. Please use kwil.call().`);
     }
 
-    /** 
-     * Specifies the signer for the action operation.
-     * 
-     * @param {SignerSupplier} signer - The signer for the database operation. This can be a signer from Ethers v5 or Ethers v6 or a custom signer function of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
-     * @param {AnySignatureType} signatureType - The signature type for the database operation. This can be a `SignatureType` enum value or a string for a network-specific signature type. Ethers v5 and Ethers v6 signers will have the signature type inferred from the signer.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the signer is null or undefined.
-     * @throws Will throw an error if the signature type is null or undefined.
-     * @throws Will throw an error if it cannot infer the signature type from the signer.
-    */
-    signer(signer: SignerSupplier, signatureType?: AnySignatureType): NonNil<ActionBuilder> {
-        this.assertNotBuilding();
+    // construct payload
+    const payload: UnencodedActionPayload<PayloadType.EXECUTE_ACTION> = {
+      dbid: dbid,
+      action: name,
+      arguments: preparedActions,
+    };
 
-        // throw runtime error if signer is null or undefined
-        this._signer = objects.requireNonNil(signer, 'no signer provided. please specify a signing function or pass an Ethers signer in the KwilSigner.');
+    // build the transaction
+    const tx = PayloadBuilderImpl.of(this.client)
+      .payloadType(PayloadType.EXECUTE_ACTION)
+      .payload(payload)
+      .signer(signer, signatureType)
+      .description(this._description)
+      .chainId(chainId)
+      .publicKey(publicKey);
 
-        if (!signatureType) {
-            // infer signature type from signer
-            this._signatureType = getSignatureType(signer);
+    return tx.buildTx();
+  }
 
-            // throw runtime error if signature type could not be inferred
-            if (this._signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
-                throw new Error("Could not determine signature type from signer. Please specify a signature type in the KwilSigner.");
-            }
-            return this;
-        }
+  /**
+   * Executes all of the required logic in the TxnBuildImpl class to build a view action for the call endpoint.
+   *
+   * @param {ActionInput[]} actions - The actions to be executed.
+   * @returns {Message} A message object that can be sent to the Kwil network.
+   * @throws Will throw an error if there's an issue with the schema or account retrieval & validation.
+   */
+  private async doBuildMsg(action: ActionInput[]): Promise<Message> {
+    // retrieve the schema and run validations
+    const { dbid, name, preparedActions, actionSchema } = await this.checkSchema(action);
 
-        // throw runtime error if signature type is null or undefined
-        this._signatureType = objects.requireNonNil(signatureType, 'signature type cannot be null or undefined. please specify signature type.');
-
-        return this;
+    // throw a runtime error if more than one set of inputs is trying to be executed. Call does not allow bulk execution.
+    if (preparedActions && preparedActions.length > 1) {
+      throw new Error(
+        'Cannot pass an array of actions inputs to a message. Please pass a single action input object.'
+      );
     }
 
-    /**
-     * Specifies the public key of the wallet signing for the database operation.
-     * 
-     * @param {HexString | Uint8Array} publicKey - The public key of the wallet signing for the database operation.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the public key is null or undefined.
-     */
-    publicKey(publicKey: HexString | Uint8Array): NonNil<ActionBuilder> {
-        this.assertNotBuilding();
-
-        // throw runtime error if public key is null or undefined
-        this._publicKey = objects.requireNonNil(publicKey, 'public key cannot be null or undefined.');
-        return this;
+    // throw runtime error if action is not a view action. transactions require a different payload structure than view actions.
+    if (actionSchema.mutability === 'update') {
+      throw new Error(`Action ${name} is not a view only action. Please use kwil.execute().`);
     }
 
-    /**
-     * Specifies the description to be included in the message that is signed.
-     * 
-     * @param {string} description - The description to be included in the message that is signed.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the description is null or undefined.
-     */
-    description(description: string): ActionBuilder {
-        this.assertNotBuilding();
+    // resolve if a signer is or is not specified. Only actions with `mustsign` require a signer.
+    const signer = this._signer ? this._signer : null;
 
-        // throw runtime error if description is null or undefined
-        this._description = objects.requireNonNil(description, 'description cannot be null or undefined.');
-        return this;
+    // construct payload. If there are no prepared actions, then the payload is an empty array.
+    const payload: UnencodedActionPayload<PayloadType.CALL_ACTION> = {
+      dbid: dbid,
+      action: name,
+      // if there are prepared actions, then the first element in the array is the action inputs.
+      arguments: preparedActions.length > 0 ? preparedActions[0] : [],
+    };
+
+    let msg: PayloadBuilder = PayloadBuilderImpl.of(this.client).payload(payload);
+
+    // if a signer is specified, add the signer, signature type, public key, and description to the message
+    if (signer) {
+      const publicKey = await Promisy.resolveOrReject(this._publicKey);
+      const signatureType = await Promisy.resolveOrReject(this._signatureType);
+      msg = msg.signer(signer, signatureType).publicKey(publicKey).description(this._description);
     }
 
+    return await msg.buildMsg();
+  }
 
-    /**
-     * Adds actionInputs to the list of inputs to be executed in the action.
-     * 
-     * @param {ActionInput | ActionInput[]} actions - The actions to add. This should be from the `ActionInput` class.
-     * @returns The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the action is null or undefined.
-     */
-    concat(actions: ActionInput[] | ActionInput): NonNil<ActionBuilder> {
-        this.assertNotBuilding();
+  /**
+   * Checks the schema and validates the actions.
+   *
+   * @param {ActionInput[]} actions - The values of the actions to be executed.
+   * @returns {CheckSchema} - An object containing the database identifier, action name, action schema, and prepared actions.
+   */
+  private async checkSchema(actions: ActionInput[]): Promise<CheckSchema> {
+    // throw runtime errors is dbid or action name is null or undefined
+    const dbid = objects.requireNonNil(
+      this._dbid,
+      'dbid is required to execute or call an action.'
+    );
+    const name = objects.requireNonNil(
+      this._name,
+      'action name is required to execute or call an action.'
+    );
 
-        // if actions is not an array, convert it to an array
-        if (!Array.isArray(actions)) {
-            actions = [actions];
-        }
+    // retrieve the schema for the database
+    const schema = await this.client.getSchema(dbid);
 
-        // loop over array of actions and add them to the list of actions
-        for (const action of actions) {
-            // push action into array and throw runtime error if action is null or undefined
-            this._actions.push(objects.requireNonNil(action, 'action cannot be null or undefined. Please pass a valid ActionInput object.'));
-        }
-
-        return this;
+    // throw an error if the schema does not have any actions.
+    if (!schema?.data?.actions) {
+      throw new Error(
+        `Could not retrieve actions for database ${dbid}. Please double check that you have the correct DBID.`
+      );
     }
 
-    /**
-     * Builds a transaction. This will call the kwil network to retrieve the schema and the signer's account.
-     * 
-     * @returns {Promise<Transaction>} - A promise that resolves to a Transaction object. This transaction can be broadcasted to the Kwil network with the `kwil.broadcast()` api.
-     * @throws Will throw an error if the action is being built or if there's an issue with the schema or account retrieval.
-     * @throws Will throw an error if the action is not a update action.
-     */
-    async buildTx(): Promise<Transaction> {
-        this.assertNotBuilding();
-
-        // cache the action
-        const cached = this._actions;
-
-        // set the actions to a special value to indicate that the transaction is being built
-        this._actions = TXN_BUILD_IN_PROGRESS;
-
-        return await this
-            // build the transaction
-            .dobuildTx(cached)
-            // set the actions back to the cached value, signaling that the transaction is no longer being built
-            .finally(() => this._actions = cached);
+    // validate the the name exists on the schema.
+    const actionSchema = schema.data.actions.find((act) => act.name == name);
+    if (!actionSchema) {
+      throw new Error(
+        `Could not find action ${name} in database ${dbid}. Please double check that you have the correct DBID and action name.`
+      );
     }
 
-    /**
-     * Builds the message structure for view actions. This can be provided to the `kwil.call()` api.
-     * 
-     * @returns {Promise<Message>} - A message object that can be sent to the Kwil network.
-     * @throws Will throw an error if the action is being built or if there's an issue with the schema or account retrieval.
-     * @throws Will throw an error if the action is not a view action.
-     */
-    async buildMsg(): Promise<Message> {
-        this.assertNotBuilding();
+    if (actions) {
+      // ensure that no action inputs or values are missing
+      const preparedActions = this.prepareActions(actions, actionSchema, name);
+      return {
+        dbid: dbid,
+        name: name,
+        actionSchema: actionSchema,
+        preparedActions: preparedActions,
+      };
+    } else {
+      return {
+        dbid: dbid,
+        name: name,
+        actionSchema: actionSchema,
+        preparedActions: [],
+      };
+    }
+  }
 
-        // cache the action
-        const cached = this._actions;
-
-        // set the actions to a special value to indicate that the message is being built
-        this._actions = TXN_BUILD_IN_PROGRESS;
-
-        return await this
-            // build the message
-            .doBuildMsg(cached)
-            // set the actions back to the cached value, signaling that the message is no longer being built
-            .finally(() => this._actions = cached);
+  /**
+   * Validates that the action is not missing any inputs.
+   *
+   * @param {ActionInput[]} actions - The values of the actions to be executed.
+   * @param {ActionSchema} actionSchema - The schema of the action to be executed.
+   * @param {string} actionName - The name of the action to be executed.
+   * @returns {ValueType[][]} - An array of arrays of values to be executed.
+   */
+  private prepareActions(
+    actions: ActionInput[],
+    actionSchema: ActionSchema,
+    actionName: string
+  ): ValueType[][] {
+    // if action does not require inputs, return an empty array
+    if ((!actionSchema.inputs || actionSchema.inputs.length === 0) && actions.length === 0) {
+      return [];
     }
 
-    /**
-     * Executes all the required logic in the TxnBuildImpl class to build a transaction.
-     * 
-     * @param {ActionInput[]} actions - The actions to be executed.
-     * @returns {Transaction} A transaction object that can be broadcasted to the Kwil network.
-     * @throws Will throw an error if there's an issue with the schema or account retrieval & validation.
-     */
-    private async dobuildTx(actions: ActionInput[]): Promise<Transaction> {
-        // retrieve the schema and run validations
-        const { dbid, name, preparedActions, actionSchema } = await this.checkSchema(actions);
-
-        // throw runtime error if signer is null or undefined
-        const signer = objects.requireNonNil(this._signer, 'signer is required to build a transaction.');
-
-        // resolve the public key and throw a runtime error if it is null or undefined
-        const publicKey = await Promisy.resolveOrReject(this._publicKey, 'public key is required to build a transaction.');
-
-        // resolve the signature type and throw a runtime error if it is null or undefined
-        const signatureType = await Promisy.resolveOrReject(this._signatureType, 'signature type is required to build a transaction.');
-
-        // throw runtime error if action is a view action. view actions require a different payload structure than transactions.
-        if (actionSchema.mutability === "view") {
-            throw new Error(`Action ${name} is a 'view' action. Please use kwil.call().`);
-        }
-
-        // construct payload
-        const payload: UnencodedActionPayload<PayloadType.EXECUTE_ACTION> = {
-            "dbid": dbid,
-            "action": name,
-            "arguments": preparedActions
-        }
-
-        // build the transaction
-        const tx = PayloadBuilderImpl
-            .of(this.client)
-            .payloadType(PayloadType.EXECUTE_ACTION)
-            .payload(payload)
-            .signer(signer, signatureType)
-            .description(this._description)
-            .publicKey(publicKey)
-
-        return tx.buildTx();
+    // throw runtime error if action does not have any inputs but inputs were provided
+    if (!actionSchema.inputs) {
+      throw new Error(`No inputs found for action schema: ${actionName}.`);
     }
 
-    /**
-     * Executes all of the required logic in the TxnBuildImpl class to build a view action for the call endpoint.
-     * 
-     * @param {ActionInput[]} actions - The actions to be executed.
-     * @returns {Message} A message object that can be sent to the Kwil network.
-     * @throws Will throw an error if there's an issue with the schema or account retrieval & validation.
-     */
-    private async doBuildMsg(action: ActionInput[]): Promise<Message> {
-        // retrieve the schema and run validations
-        const { dbid, name, preparedActions, actionSchema } = await this.checkSchema(action);
-
-        // throw a runtime error if more than one set of inputs is trying to be executed. Call does not allow bulk execution.
-        if (preparedActions && preparedActions.length > 1) {
-            throw new Error("Cannot pass an array of actions inputs to a message. Please pass a single action input object.");
-        }
-
-        // throw runtime error if action is not a view action. transactions require a different payload structure than view actions.
-        if (actionSchema.mutability === "update") {
-            throw new Error(`Action ${name} is not a view only action. Please use kwil.execute().`);
-        }
-
-        // resolve if a signer is or is not specified. Only actions with `mustsign` require a signer.
-        const signer = this._signer ? this._signer : null;
-
-        // construct payload. If there are no prepared actions, then the payload is an empty array.
-        const payload: UnencodedActionPayload<PayloadType.CALL_ACTION> = {
-            "dbid": dbid,
-            "action": name,
-            // if there are prepared actions, then the first element in the array is the action inputs.
-            "arguments": preparedActions.length > 0 ? preparedActions[0] : []
-        }
-
-        let msg: PayloadBuilder = PayloadBuilderImpl
-            .of(this.client)
-            .payload(payload)
-
-        // if a signer is specified, add the signer, signature type, public key, and description to the message
-        if (signer) {
-            const publicKey = await Promisy.resolveOrReject(this._publicKey);
-            const signatureType = await Promisy.resolveOrReject(this._signatureType);
-            msg = msg
-                .signer(signer, signatureType)
-                .publicKey(publicKey)
-                .description(this._description);
-        }
-
-        return await msg.buildMsg();
+    // throw runtime error if no actions were provided but inputs are required
+    if (actions.length == 0) {
+      throw new Error('No action data has been added to the ActionBuilder.');
     }
 
-    /**
-     * Checks the schema and validates the actions.
-     * 
-     * @param {ActionInput[]} actions - The values of the actions to be executed. 
-     * @returns {CheckSchema} - An object containing the database identifier, action name, action schema, and prepared actions.
-     */
-    private async checkSchema(actions: ActionInput[]): Promise<CheckSchema> {
-        // throw runtime errors is dbid or action name is null or undefined
-        const dbid = objects.requireNonNil(this._dbid, 'dbid is required to execute or call an action.');
-        const name = objects.requireNonNil(this._name, 'action name is required to execute or call an action.');
+    // track the missing actions
+    const missingActions = new Set<string>();
+    actionSchema.inputs.forEach((i) => {
+      const found = actions.find((a) => a.containsKey(i));
+      if (!found) {
+        missingActions.add(i);
+      }
+    });
 
-        // retrieve the schema for the database
-        const schema = await this.client.getSchema(dbid);
-
-        // throw an error if the schema does not have any actions.
-        if (!schema?.data?.actions) {
-            throw new Error(`Could not retrieve actions for database ${dbid}. Please double check that you have the correct DBID.`);
-        }
-
-        // validate the the name exists on the schema.
-        const actionSchema = schema.data.actions.find((act) => act.name == name);
-        if (!actionSchema) {
-            throw new Error(`Could not find action ${name} in database ${dbid}. Please double check that you have the correct DBID and action name.`);
-        }
-
-        if (actions) {
-            // ensure that no action inputs or values are missing
-            const preparedActions = this.prepareActions(actions, actionSchema, name);
-            return {
-                dbid: dbid,
-                name: name,
-                actionSchema: actionSchema,
-                preparedActions: preparedActions
-            }
-        } else {
-            return {
-                dbid: dbid,
-                name: name,
-                actionSchema: actionSchema,
-                preparedActions: []
-            }
-        }
+    if (missingActions.size > 0) {
+      throw new Error(`Actions do not match action schema inputs: ${Array.from(missingActions)}`);
     }
 
-    /**
-     * Validates that the action is not missing any inputs. 
-     * 
-     * @param {ActionInput[]} actions - The values of the actions to be executed.
-     * @param {ActionSchema} actionSchema - The schema of the action to be executed.
-     * @param {string} actionName - The name of the action to be executed.
-     * @returns {ValueType[][]} - An array of arrays of values to be executed.
-     */
-    private prepareActions(actions: ActionInput[], actionSchema: ActionSchema, actionName: string): ValueType[][] {
-        // if action does not require inputs, return an empty array
-        if ((!actionSchema.inputs || actionSchema.inputs.length === 0) && actions.length === 0) {
-            return [];
+    const preparedActions: ValueType[][] = [];
+    const missingInputs = new Set<string>();
+    actions.forEach((a) => {
+      const copy = ActionInput.from(a);
+      actionSchema.inputs.forEach((i) => {
+        if (missingInputs.has(i)) {
+          return;
         }
 
-        // throw runtime error if action does not have any inputs but inputs were provided
-        if (!actionSchema.inputs) {
-            throw new Error(`No inputs found for action schema: ${actionName}.`)
+        if (!copy.containsKey(i)) {
+          missingInputs.add(i);
+          return;
         }
-
-        // throw runtime error if no actions were provided but inputs are required
-        if (actions.length == 0) {
-            throw new Error("No action data has been added to the ActionBuilder.");
-        }
-
-        // track the missing actions
-        const missingActions = new Set<string>();
-        actionSchema.inputs.forEach((i) => {
-            const found = actions.find((a) => a.containsKey(i));
-            if (!found) {
-                missingActions.add(i);
-            }
-        });
-
-        if (missingActions.size > 0) {
-            throw new Error(`Actions do not match action schema inputs: ${Array.from(missingActions)}`)
-        }
-
-        const preparedActions: ValueType[][] = [];
-        const missingInputs = new Set<string>();
-        actions.forEach((a) => {
-            const copy = ActionInput.from(a);
-            actionSchema.inputs.forEach((i) => {
-                if (missingInputs.has(i)) {
-                    return;
-                }
-
-                if (!copy.containsKey(i)) {
-                    missingInputs.add(i);
-                    return;
-                }
-
-                if (missingInputs.size > 0) {
-                    return;
-                }
-
-                const val = copy.get(i);
-
-                copy.put(i, val);
-            })
-
-            if (missingInputs.size === 0) {
-                preparedActions.push(actionSchema.inputs.map((i) => {
-                    const val = copy.get(i)
-                    if (val) {
-                        return val.toString();
-                    }
-                    return val;
-                }));
-            }
-        });
 
         if (missingInputs.size > 0) {
-            throw new Error(`Inputs are missing for actions: ${Array.from(missingInputs)}`)
+          return;
         }
 
-        return preparedActions;
+        const val = copy.get(i);
+
+        copy.put(i, val);
+      });
+
+      if (missingInputs.size === 0) {
+        preparedActions.push(
+          actionSchema.inputs.map((i) => {
+            const val = copy.get(i);
+            if (val) {
+              return val.toString();
+            }
+            return val;
+          })
+        );
+      }
+    });
+
+    if (missingInputs.size > 0) {
+      throw new Error(`Inputs are missing for actions: ${Array.from(missingInputs)}`);
     }
 
-    private assertNotBuilding(): void {
-        if (this._actions === TXN_BUILD_IN_PROGRESS) {
-            throw new Error("Cannot modify the builder while a transaction is being built.");
-        }
+    return preparedActions;
+  }
+
+  private assertNotBuilding(): void {
+    if (this._actions === TXN_BUILD_IN_PROGRESS) {
+      throw new Error('Cannot modify the builder while a transaction is being built.');
     }
+  }
 }

--- a/src/builders/db_builder.ts
+++ b/src/builders/db_builder.ts
@@ -1,14 +1,14 @@
-import { Transaction } from "../core/tx";
-import { Nillable, NonNil, Promisy } from "../utils/types";
-import { objects } from "../utils/objects";
-import { Kwil } from "../client/kwil";
-import { PayloadBuilderImpl } from "./payload_builder";
-import { DBBuilder, SignerSupplier } from "../core/builders";
-import { AttributeType, DataType, DeployOrDrop, IndexType, PayloadType } from "../core/enums";
-import { Database } from "../core/database";
-import { enforceDatabaseOrder } from "../core/order";
-import { AnySignatureType, SignatureType, getSignatureType } from "../core/signature";
-import { CompiledKuneiform, DbPayloadType, DropDbPayload } from "../core/payload";
+import { Transaction } from '../core/tx';
+import { Nillable, NonNil, Promisy } from '../utils/types';
+import { objects } from '../utils/objects';
+import { Kwil } from '../client/kwil';
+import { PayloadBuilderImpl } from './payload_builder';
+import { DBBuilder, SignerSupplier } from '../core/builders';
+import { AttributeType, DataType, DeployOrDrop, IndexType, PayloadType } from '../core/enums';
+import { Database } from '../core/database';
+import { enforceDatabaseOrder } from '../core/order';
+import { AnySignatureType, SignatureType, getSignatureType } from '../core/signature';
+import { CompiledKuneiform, DbPayloadType, DropDbPayload } from '../core/payload';
 
 /**
  * `DBBuilderImpl` class is an implementation of the `DBBuilder` interface.
@@ -16,321 +16,386 @@ import { CompiledKuneiform, DbPayloadType, DropDbPayload } from "../core/payload
  */
 
 export class DBBuilderImpl<T extends DeployOrDrop> implements DBBuilder<T> {
-    private readonly client: Kwil;
-    private _payload: Nillable<() => NonNil<CompiledKuneiform | DropDbPayload>> = null;
-    private _signer: Nillable<SignerSupplier> = null;
-    private _signatureType: Nillable<AnySignatureType>;
-    private _payloadType: Nillable<PayloadType> = null;
-    private _publicKey: Nillable<string | Uint8Array> = null;
-    private _description: Nillable<string> = null;
+  private readonly client: Kwil;
+  private _payload: Nillable<() => NonNil<CompiledKuneiform | DropDbPayload>> = null;
+  private _signer: Nillable<SignerSupplier> = null;
+  private _signatureType: Nillable<AnySignatureType>;
+  private _payloadType: Nillable<PayloadType> = null;
+  private _publicKey: Nillable<string | Uint8Array> = null;
+  private _chainId: Nillable<string> = null;
+  private _description: Nillable<string> = null;
 
-    /**
-     * Initializes a new `DBBuilderImpl` instance.
-     * 
-     * @param {Kwil} client = The Kwil client, used to call higher level methods on the Kwil class.
-     * @param {DeployOrDrop} payloadType - The payload type for the database transaction. This should be `PayloadType.DEPLOY_DATABASE` or `PayloadType.DROP_DATABASE`.
-     * @returns {DBBuilder} A new `DBBuilderImpl` instance.
-     */
-    private constructor(client: Kwil, payloadType: DeployOrDrop) {
-        this.client = client;
-        this._payloadType = payloadType;
-    }
+  /**
+   * Initializes a new `DBBuilderImpl` instance.
+   *
+   * @param {Kwil} client = The Kwil client, used to call higher level methods on the Kwil class.
+   * @param {DeployOrDrop} payloadType - The payload type for the database transaction. This should be `PayloadType.DEPLOY_DATABASE` or `PayloadType.DROP_DATABASE`.
+   * @returns {DBBuilder} A new `DBBuilderImpl` instance.
+   */
+  private constructor(client: Kwil, payloadType: DeployOrDrop) {
+    this.client = client;
+    this._payloadType = payloadType;
+  }
 
-    /**
-     * Creates a new `DbBuilder` instance.
-     * 
-     * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
-     * @param {PayloadType} payloadType - The payload type for the database transaction. This should be `PayloadType.DEPLOY_DATABASE` or `PayloadType.DROP_DATABASE`.
-     * @returns {DBBuilder} A new `DBBuilderImpl` instance.
-     */
-    public static of<T extends DeployOrDrop>(client: NonNil<Kwil>, payloadType: NonNil<DeployOrDrop>): NonNil<DBBuilder<T>> {
-        // throw runtime error if client or payloadType is null
-        return new DBBuilderImpl<T>(
-            objects.requireNonNil(client, 'client is required for DbBuilder. Please pass a valid Kwil client. This is an internal error, please create an issue.'),
-            objects.requireNonNil(payloadType, 'payloadType is required for DbBuilder. Please pass a valid PayloadType. This is an internal error, please create an issue.')
+  /**
+   * Creates a new `DbBuilder` instance.
+   *
+   * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
+   * @param {PayloadType} payloadType - The payload type for the database transaction. This should be `PayloadType.DEPLOY_DATABASE` or `PayloadType.DROP_DATABASE`.
+   * @returns {DBBuilder} A new `DBBuilderImpl` instance.
+   */
+  public static of<T extends DeployOrDrop>(
+    client: NonNil<Kwil>,
+    payloadType: NonNil<DeployOrDrop>
+  ): NonNil<DBBuilder<T>> {
+    // throw runtime error if client or payloadType is null
+    return new DBBuilderImpl<T>(
+      objects.requireNonNil(
+        client,
+        'client is required for DbBuilder. Please pass a valid Kwil client. This is an internal error, please create an issue.'
+      ),
+      objects.requireNonNil(
+        payloadType,
+        'payloadType is required for DbBuilder. Please pass a valid PayloadType. This is an internal error, please create an issue.'
+      )
+    );
+  }
+
+  /**
+   * Specifies the signer for the database transaction.
+   *
+   * @param {SignerSupplier} signer - The signer for the database transaction. This can be a `Signer` from Ethers v5 or Ethers v6 or a custom signer function. Custom signers must be of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
+   * @param {AnySignatureType} signatureType - The signature type for the database transaction. This is only required if the signer is a custom signer function.
+   * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
+   * @throws Will throw an error if the signer is null or undefined.
+   * @throws Will throw an error if the signature type is null or undefined.
+   * @throws Will throw an error if it cannot infer the signature type from the signer.
+   */
+  signer(signer: SignerSupplier, signatureType?: AnySignatureType): NonNil<DBBuilder<T>> {
+    // throw runtime error if signer is null
+    this._signer = objects.requireNonNil(
+      signer,
+      'no signer provided. please specify a signing function or pass an Ethers signer in the KwilSigner.'
+    );
+
+    if (!signatureType) {
+      // infer signature type from signer
+      this._signatureType = getSignatureType(signer);
+
+      // throw runtime error if signature type is null
+      if (this._signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
+        throw new Error(
+          'Could not determine signature type from signer. Please pass a signature type to .signer().'
         );
+      }
+      return this;
     }
 
-    /**
-     * Specifies the signer for the database transaction.
-     * 
-     * @param {SignerSupplier} signer - The signer for the database transaction. This can be a `Signer` from Ethers v5 or Ethers v6 or a custom signer function. Custom signers must be of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
-     * @param {AnySignatureType} signatureType - The signature type for the database transaction. This is only required if the signer is a custom signer function. 
-     * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-     * @throws Will throw an error if the signer is null or undefined.
-     * @throws Will throw an error if the signature type is null or undefined.
-     * @throws Will throw an error if it cannot infer the signature type from the signer.
-     */
-    signer(signer: SignerSupplier, signatureType?: AnySignatureType): NonNil<DBBuilder<T>> {
-        // throw runtime error if signer is null
-        this._signer = objects.requireNonNil(signer, 'no signer provided. please specify a signing function or pass an Ethers signer in the KwilSigner.');
+    // throw runtime error if signature type is null
+    this._signatureType = objects.requireNonNil(
+      signatureType,
+      'signature type cannot be null or undefined. please specify signature type.'
+    );
 
-        if (!signatureType) {
-            // infer signature type from signer
-            this._signatureType = getSignatureType(signer);
+    return this;
+  }
 
-            // throw runtime error if signature type is null
-            if (this._signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
-                throw new Error("Could not determine signature type from signer. Please pass a signature type to .signer().");
-            }
-            return this;
+  /**
+   * The payload for the database deployment or database drop.
+   *
+   * @param {DbPayloadType<T>} payload - The payload for the database deployment or database drop. This should be a callback function that resolves to either a `CompiledKuneiform` or `DropDbPayload` object, or just objects that match either of those interfaces.
+   * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
+   * @throws Will throw an error if the payload is null or undefined.
+   */
+  payload(payload: DbPayloadType<T>): NonNil<DBBuilder<T>> {
+    // throw runtime error if payload is null
+    const ensuredPayload = objects.requireNonNil(payload, 'dbBuilder payload cannot be null');
+    // ensure payload is a callback function for lazy evaluation
+    this._payload =
+      typeof ensuredPayload !== 'function'
+        ? () => ensuredPayload
+        : (ensuredPayload as () => NonNil<CompiledKuneiform | DropDbPayload>);
+    return this;
+  }
+
+  /**
+   * Specifies the public key for the database deployment / drop.
+   *
+   * @param {string | Uint8Array} publicKey - The public key for the database deployment / drop.
+   * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
+   * @throws Will throw an error if the public key is null or undefined.
+   */
+  publicKey(publicKey: string | Uint8Array): NonNil<DBBuilder<T>> {
+    // throw runtime error if public key is null
+    this._publicKey = objects.requireNonNil(
+      publicKey,
+      'public key is required for DbBuilder. Please pass a valid public key.'
+    );
+    return this;
+  }
+
+  /**
+   * Specifies the chain ID for the network being used.
+   *
+   * @param {string} chainId - The chain ID for the network being used.
+   * @returns {DBBuilder} The current `ActionBuilder` instance for chaining.
+   */
+  chainId(chainId: string): NonNil<DBBuilder<T>> {
+    this._chainId = objects.requireNonNil(chainId, 'chain ID cannot be null or undefined.');
+    return this;
+  }
+
+  /**
+   * Specifies the descriptions to be included in the message that is signed.
+   *
+   * @param {string} description - The description to be included in the message that is signed.
+   * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
+   * @throws Will throw an error if the description is null or undefined.
+   */
+  description(description: string): NonNil<DBBuilder<T>> {
+    // throw runtime error if description is null
+    this._description = objects.requireNonNil(
+      description,
+      'description cannot be null or undefined.'
+    );
+    return this;
+  }
+
+  /**
+   * Builds a Transaction. This will call the kwil network to retrieve the nonce for the signer.
+   *
+   * @returns {Promise<Transaction>} - A promise that resolves to a `Transaction` object. The `Transaction` object can be broadcasted to the Kwil network using `kwil.broadcast(tx)`.
+   * @throws Will throw an error if there are any errors in the payload.
+   * @throws Will throw an error if there is an issue with the account retrieval.
+   */
+  async buildTx(): Promise<Transaction> {
+    // throw runtime error if payload is null
+    const payload = objects.requireNonNil(
+      this._payload,
+      'payload cannot be null or undefined. please provide a payload to DBBuilder.'
+    );
+
+    // create cleanedPayload that is equal to the current callback function
+    let cleanedPayload: () => NonNil<object> = () => payload();
+
+    // if it is a deploy database, we need to add all of the required fields and field order to make it RLP encodable. The Kuneiform parser does not include null fields.
+    if (this._payloadType === PayloadType.DEPLOY_DATABASE) {
+      // make the payload encodable
+      const encodablePayload = this.makePayloadEncodable(
+        payload as () => NonNil<CompiledKuneiform>
+      );
+      // reassign cleanedPayload to be a callback function that returns the encodable payload with the correct order
+      cleanedPayload = () => enforceDatabaseOrder(encodablePayload);
+    }
+
+    // throw runtime errors if any of the required fields are null
+    const payloadType = objects.requireNonNil(
+      this._payloadType,
+      'payload type cannot be null or undefined. please specify a payload type.'
+    );
+    const signer = objects.requireNonNil(
+      this._signer,
+      'signer cannot be null or undefined. please specify a signer.'
+    );
+    const publicKey = objects.requireNonNil(
+      this._publicKey,
+      'public key cannot be null or undefined. please specify a public key.'
+    );
+    const chainId = objects.requireNonNil(
+      this._chainId,
+      'chain ID cannot be null or undefined. please specify a chain ID.'
+    );
+    const signatureType = await Promisy.resolveOrReject(
+      this._signatureType,
+      'signature type cannot be null or undefined. please specify a signature type.'
+    );
+
+    const tx = PayloadBuilderImpl.of(this.client)
+      .payloadType(payloadType)
+      .payload(cleanedPayload)
+      .signer(signer, signatureType)
+      .publicKey(publicKey)
+      .chainId(chainId)
+      .description(this._description);
+    return tx.buildTx();
+  }
+
+  /**
+   * Ensures the compiled kuneiform schema has all of the required fields for RLP encoding.
+   *
+   * @param payload
+   * @returns
+   */
+  private makePayloadEncodable(payload: () => NonNil<CompiledKuneiform>): NonNil<Database> {
+    // check if the payload has the required fields for the database
+
+    const resolvedPayload = payload();
+
+    let db: Database = resolvedPayload as Database;
+
+    if (!db.owner) {
+      db.owner = new Uint8Array();
+    }
+
+    if (!db.name) {
+      db.name = '';
+    }
+
+    if (!db.tables) {
+      db.tables = [];
+    }
+
+    db.tables &&
+      db.tables.forEach((table) => {
+        if (!table.name) {
+          table.name = '';
         }
 
-        // throw runtime error if signature type is null
-        this._signatureType = objects.requireNonNil(signatureType, 'signature type cannot be null or undefined. please specify signature type.');
-
-        return this;
-    }
-
-    /**
-     * The payload for the database deployment or database drop.
-     * 
-     * @param {DbPayloadType<T>} payload - The payload for the database deployment or database drop. This should be a callback function that resolves to either a `CompiledKuneiform` or `DropDbPayload` object, or just objects that match either of those interfaces.
-     * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-     * @throws Will throw an error if the payload is null or undefined.
-     */
-    payload(payload: DbPayloadType<T>): NonNil<DBBuilder<T>> {
-        // throw runtime error if payload is null
-        const ensuredPayload = objects.requireNonNil(payload, 'dbBuilder payload cannot be null');
-        // ensure payload is a callback function for lazy evaluation
-        this._payload = typeof ensuredPayload !== "function" ?
-            () => ensuredPayload :
-            ensuredPayload as () => NonNil<CompiledKuneiform | DropDbPayload>;
-        return this;
-    }
-
-    /**
-     * Specifies the public key for the database deployment / drop.
-     * 
-     * @param {string | Uint8Array} publicKey - The public key for the database deployment / drop. 
-     * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-     * @throws Will throw an error if the public key is null or undefined.
-     */
-    publicKey(publicKey: string | Uint8Array): NonNil<DBBuilder<T>> {
-        // throw runtime error if public key is null
-        this._publicKey = objects.requireNonNil(publicKey, 'public key is required for DbBuilder. Please pass a valid public key.');
-        return this;
-    }
-
-    /**
-     * Specifies the descriptions to be included in the message that is signed.
-     * 
-     * @param {string} description - The description to be included in the message that is signed. 
-     * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-     * @throws Will throw an error if the description is null or undefined.
-     */
-    description(description: string): NonNil<DBBuilder<T>> {
-        // throw runtime error if description is null
-        this._description = objects.requireNonNil(description, 'description cannot be null or undefined.');
-        return this;
-    }
-
-    /**
-     * Builds a Transaction. This will call the kwil network to retrieve the nonce for the signer.
-     * 
-     * @returns {Promise<Transaction>} - A promise that resolves to a `Transaction` object. The `Transaction` object can be broadcasted to the Kwil network using `kwil.broadcast(tx)`.
-     * @throws Will throw an error if there are any errors in the payload.
-     * @throws Will throw an error if there is an issue with the account retrieval.
-     */
-    async buildTx(): Promise<Transaction> {
-        // throw runtime error if payload is null
-        const payload = objects.requireNonNil(this._payload, 'payload cannot be null or undefined. please provide a payload to DBBuilder.');
-
-        // create cleanedPayload that is equal to the current callback function
-        let cleanedPayload: () => NonNil<object> = () => payload();
-
-        // if it is a deploy database, we need to add all of the required fields and field order to make it RLP encodable. The Kuneiform parser does not include null fields.
-        if (this._payloadType === PayloadType.DEPLOY_DATABASE) {
-            // make the payload encodable
-            const encodablePayload = this.makePayloadEncodable(payload as () => NonNil<CompiledKuneiform>);
-            // reassign cleanedPayload to be a callback function that returns the encodable payload with the correct order
-            cleanedPayload = () => enforceDatabaseOrder(encodablePayload);
+        if (!table.columns) {
+          table.columns = [];
         }
 
-        // throw runtime errors if any of the required fields are null
-        const payloadType = objects.requireNonNil(this._payloadType, 'payload type cannot be null or undefined. please specify a payload type.');
-        const signer = objects.requireNonNil(this._signer, 'signer cannot be null or undefined. please specify a signer.')
-        const publicKey = objects.requireNonNil(this._publicKey, 'public key cannot be null or undefined. please specify a public key.');
-        const signatureType = await Promisy.resolveOrReject(this._signatureType, 'signature type cannot be null or undefined. please specify a signature type.');
+        table.columns &&
+          table.columns.forEach((column) => {
+            if (!column.name) {
+              column.name = '';
+            }
 
+            if (!column.type) {
+              column.type = DataType.NULL;
+            }
 
-        const tx = PayloadBuilderImpl
-            .of(this.client)
-            .payloadType(payloadType)
-            .payload(cleanedPayload)
-            .signer(signer, signatureType)
-            .publicKey(publicKey)
-            .description(this._description)
-        return tx.buildTx();
-    }
+            if (!column.attributes) {
+              column.attributes = [];
+            }
 
-    /**
-     * Ensures the compiled kuneiform schema has all of the required fields for RLP encoding.
-     * 
-     * @param payload 
-     * @returns 
-     */
-    private makePayloadEncodable(payload: (() => NonNil<CompiledKuneiform>)): NonNil<Database> {
-        // check if the payload has the required fields for the database
+            column.attributes &&
+              column.attributes.forEach((attribute) => {
+                if (!attribute.type) {
+                  attribute.type = AttributeType.INVALID_TYPE;
+                }
 
-        const resolvedPayload = payload();
+                if (!attribute.value) {
+                  attribute.value = '';
+                }
+              });
+          });
 
-        let db: Database = resolvedPayload as Database;
-
-        if (!db.owner) {
-            db.owner = new Uint8Array();
-        };
-
-        if (!db.name) {
-            db.name = "";
+        if (!table.indexes) {
+          table.indexes = [];
         }
 
-        if (!db.tables) {
-            db.tables = [];
+        table.indexes &&
+          table.indexes.forEach((index) => {
+            if (!index.name) {
+              index.name = '';
+            }
+
+            if (!index.columns) {
+              index.columns = [];
+            }
+
+            if (!index.type) {
+              index.type = IndexType.INVALID_INDEX_TYPE;
+            }
+          });
+
+        if (!table.foreign_keys) {
+          table.foreign_keys = [];
         }
 
-        db.tables && db.tables.forEach(table => {
-            if (!table.name) {
-                table.name = "";
+        table.foreign_keys &&
+          table.foreign_keys.forEach((foreign_key) => {
+            if (!foreign_key.child_keys) {
+              foreign_key.child_keys = [];
             }
 
-            if (!table.columns) {
-                table.columns = [];
+            if (!foreign_key.parent_keys) {
+              foreign_key.parent_keys = [];
             }
 
-            table.columns && table.columns.forEach(column => {
-                if (!column.name) {
-                    column.name = "";
+            if (!foreign_key.parent_table) {
+              foreign_key.parent_table = '';
+            }
+
+            if (!foreign_key.actions) {
+              foreign_key.actions = [];
+            }
+
+            foreign_key.actions &&
+              foreign_key.actions.forEach((action) => {
+                if (!action.on) {
+                  action.on = '';
                 }
 
-                if (!column.type) {
-                    column.type = DataType.NULL;
+                if (!action.do) {
+                  action.do = '';
                 }
+              });
+          });
+      });
 
-                if (!column.attributes) {
-                    column.attributes = [];
-                }
-
-                column.attributes && column.attributes.forEach(attribute => {
-                    if (!attribute.type) {
-                        attribute.type = AttributeType.INVALID_TYPE;
-                    }
-
-                    if (!attribute.value) {
-                        attribute.value = "";
-                    }
-                });
-            });
-
-            if (!table.indexes) {
-                table.indexes = [];
-            }
-
-            table.indexes && table.indexes.forEach(index => {
-                if (!index.name) {
-                    index.name = "";
-                }
-
-                if (!index.columns) {
-                    index.columns = [];
-                }
-
-                if (!index.type) {
-                    index.type = IndexType.INVALID_INDEX_TYPE;
-                }
-            });
-
-            if (!table.foreign_keys) {
-                table.foreign_keys = [];
-            }
-
-            table.foreign_keys && table.foreign_keys.forEach(foreign_key => {
-                if (!foreign_key.child_keys) {
-                    foreign_key.child_keys = [];
-                }
-
-                if (!foreign_key.parent_keys) {
-                    foreign_key.parent_keys = [];
-                }
-
-                if (!foreign_key.parent_table) {
-                    foreign_key.parent_table = "";
-                }
-
-                if (!foreign_key.actions) {
-                    foreign_key.actions = [];
-                }
-
-                foreign_key.actions && foreign_key.actions.forEach(action => {
-                    if (!action.on) {
-                        action.on = "";
-                    }
-
-                    if (!action.do) {
-                        action.do = "";
-                    }
-                });
-            });
-        });
-
-        if (!db.actions) {
-            db.actions = [];
-        };
-
-        db.actions && db.actions.forEach(action => {
-            if (!action.name) {
-                action.name = "";
-            }
-
-            if (!action.inputs) {
-                action.inputs = [];
-            }
-
-            if (!action.mutability) {
-                action.mutability = "";
-            }
-
-            if (!action.auxiliaries) {
-                action.auxiliaries = [];
-            }
-
-            if (!action.public) {
-                action.public = true;
-            }
-
-            if (!action.statements) {
-                action.statements = [];
-            }
-        });
-
-        if (!db.extensions) {
-            db.extensions = [];
-        };
-
-        db.extensions && db.extensions.forEach(extension => {
-            if (!extension.name) {
-                extension.name = "";
-            }
-
-            if (!extension.config) {
-                extension.config = [];
-            }
-
-            if (!extension.alias) {
-                extension.alias = "";
-            }
-
-            extension.config && extension.config.forEach(config => {
-                if (!config.Argument) {
-                    config.Argument = "";
-                }
-
-                if (!config.Value) {
-                    config.Value = "";
-                }
-            });
-        });
-
-        return db;
+    if (!db.actions) {
+      db.actions = [];
     }
+
+    db.actions &&
+      db.actions.forEach((action) => {
+        if (!action.name) {
+          action.name = '';
+        }
+
+        if (!action.inputs) {
+          action.inputs = [];
+        }
+
+        if (!action.mutability) {
+          action.mutability = '';
+        }
+
+        if (!action.auxiliaries) {
+          action.auxiliaries = [];
+        }
+
+        if (!action.public) {
+          action.public = true;
+        }
+
+        if (!action.statements) {
+          action.statements = [];
+        }
+      });
+
+    if (!db.extensions) {
+      db.extensions = [];
+    }
+
+    db.extensions &&
+      db.extensions.forEach((extension) => {
+        if (!extension.name) {
+          extension.name = '';
+        }
+
+        if (!extension.config) {
+          extension.config = [];
+        }
+
+        if (!extension.alias) {
+          extension.alias = '';
+        }
+
+        extension.config &&
+          extension.config.forEach((config) => {
+            if (!config.Argument) {
+              config.Argument = '';
+            }
+
+            if (!config.Value) {
+              config.Value = '';
+            }
+          });
+      });
+
+    return db;
+  }
 }

--- a/src/builders/payload_builder.ts
+++ b/src/builders/payload_builder.ts
@@ -1,341 +1,428 @@
-import { HexString, Nillable, NonNil } from "../utils/types";
-import { BaseTransaction, Transaction } from "../core/tx";
-import { objects } from "../utils/objects";
-import { strings } from "../utils/strings";
-import { Txn } from "../core/tx";
-import { generateSalt, sha256BytesToBytes } from "../utils/crypto";
-import { base64ToBytes, bytesToBase64 } from "../utils/base64";
-import { Kwil } from "../client/kwil";
-import { SignerSupplier, PayloadBuilder as PayloadBuilder } from "../core/builders";
-import { unwrap } from "../client/intern";
-import { BytesEncodingStatus, PayloadType, SerializationType } from "../core/enums";
-import { kwilEncode } from "../utils/rlp";
-import { bytesToHex, hexToBytes, stringToBytes } from "../utils/serial";
-import { AnySignatureType, SignatureType, executeSign } from "../core/signature";
-import { BaseMessage, Message, Msg } from "../core/message";
-import { isNearPubKey, nearB58ToHex } from "../utils/keys";
-import { AllPayloads, UnencodedActionPayload } from "../core/payload";
+import { HexString, Nillable, NonNil } from '../utils/types';
+import { BaseTransaction, Transaction } from '../core/tx';
+import { objects } from '../utils/objects';
+import { strings } from '../utils/strings';
+import { Txn } from '../core/tx';
+import { sha256BytesToBytes } from '../utils/crypto';
+import { base64ToBytes, bytesToBase64 } from '../utils/base64';
+import { Kwil } from '../client/kwil';
+import { SignerSupplier, PayloadBuilder as PayloadBuilder } from '../core/builders';
+import { unwrap } from '../client/intern';
+import { BytesEncodingStatus, PayloadType, SerializationType } from '../core/enums';
+import { kwilEncode } from '../utils/rlp';
+import { bytesToHex, hexToBytes, stringToBytes } from '../utils/serial';
+import { AnySignatureType, SignatureType, executeSign } from '../core/signature';
+import { BaseMessage, Message, Msg } from '../core/message';
+import { isNearPubKey, nearB58ToHex } from '../utils/keys';
+import { AllPayloads, UnencodedActionPayload } from '../core/payload';
 
 /**
  * PayloadBuilderImpl is the default implementation of PayloadBuilder. It allows for building transaction and call payloads that can be sent over GRPC.
  * See the proto files for more information on the structure of the payloads. {@link https://github.com/kwilteam/proto/tree/main/kwil/tx/v1}
  */
 export class PayloadBuilderImpl implements PayloadBuilder {
-    private readonly client: Kwil;
-    private _payloadType: Nillable<PayloadType> = null;
-    private _payload: Nillable<() => NonNil<AllPayloads>> = null;
-    private _signer: Nillable<SignerSupplier> = null;
-    private _publicKey: Nillable<Uint8Array> = null;
-    private _signatureType: Nillable<AnySignatureType> = null;
-    private _description: NonNil<string> = "";
+  private readonly client: Kwil;
+  private _payloadType: Nillable<PayloadType> = null;
+  private _payload: Nillable<() => NonNil<AllPayloads>> = null;
+  private _signer: Nillable<SignerSupplier> = null;
+  private _publicKey: Nillable<Uint8Array> = null;
+  private _signatureType: Nillable<AnySignatureType> = null;
+  private _chainId: Nillable<string> = null;
+  private _description: NonNil<string> = '';
 
-    /**
-     * Initializes a new `PayloadBuilder` instance.
-     * 
-     * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
-     * @returns {PayloadBuilderImpl} - A new `PayloadBuilder` instance.
-     */
-    private constructor(client: Kwil) {
-        this.client = objects.requireNonNil(client, 'client is required for TxnBuilder. Please pass a valid Kwil client. This is an internal error, please create an issue.');
+  /**
+   * Initializes a new `PayloadBuilder` instance.
+   *
+   * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
+   * @returns {PayloadBuilderImpl} - A new `PayloadBuilder` instance.
+   */
+  private constructor(client: Kwil) {
+    this.client = objects.requireNonNil(
+      client,
+      'client is required for TxnBuilder. Please pass a valid Kwil client. This is an internal error, please create an issue.'
+    );
+  }
+
+  /**
+   * Creates a new `PayloadBuilder` instance.
+   *
+   * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
+   * @returns {PayloadBuilder} - A new `PayloadBuilder` instance.
+   */
+  public static of(client: NonNil<Kwil>): NonNil<PayloadBuilder> {
+    return new PayloadBuilderImpl(client);
+  }
+
+  /**
+   * Specify the payload type to be built.
+   *
+   * @param {PayloadType} payloadType - The payload type to be built. See {@link PayloadType} for more information.
+   * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
+   * @throws {Error} - If the payload type is null or undefined.
+   */
+  payloadType(payloadType: NonNil<PayloadType>): PayloadBuilder {
+    // throw runtime error if payload type is null or undefined
+    this._payloadType = objects.requireNonNil(
+      payloadType,
+      'payload type is required to build a transaction.'
+    );
+    return this;
+  }
+
+  /**
+   * Specify the signer and the signature type.
+   *
+   * @param {SignerSupplier} signer - The signer to be used to sign the transaction.
+   * @param {AnySignatureType} sigType - The signature type to be used to sign the transaction. See {@link SignatureType} for more information.
+   * @returns The current `PayloadBuilder` instance for chaining.
+   * @throws {Error} - If the signer is null or undefined.
+   * @throws {Error} - If the signature type is null or undefined.
+   */
+  signer(signer: SignerSupplier, sigType: AnySignatureType): NonNil<PayloadBuilder> {
+    // throw runtime errors if signer or signature type are null or undefined
+    this._signer = objects.requireNonNil(signer);
+    this._signatureType = objects.requireNonNil(
+      sigType,
+      'signature type is required to build a transaction.'
+    );
+    return this;
+  }
+
+  /**
+   * Sets the content for the body of the payload object.
+   *
+   * @param {() => NonNil<AllPayloads> | NonNil<AllPayloads>} payload - The payload to be built. This can be a function that returns an object or an object.
+   * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
+   * @throws {Error} - If the payload is null or undefined.
+   */
+  payload(payload: (() => NonNil<AllPayloads>) | NonNil<AllPayloads>): NonNil<PayloadBuilder> {
+    // throw runtime error if payload is null or undefined
+    const ensuredPayload = objects.requireNonNil(payload, 'transaction payload cannot be null.');
+
+    // ensure payload is a function for lazy evaluation
+    this._payload =
+      typeof ensuredPayload !== 'function'
+        ? () => ensuredPayload
+        : (ensuredPayload as () => NonNil<AllPayloads>);
+
+    return this;
+  }
+
+  /**
+   * Specify the public key for the payload signer.
+   *
+   * @param {HexString | Uint8Array} publicKey - The public key to be used to sign the transaction. This can be a hex string or a Uint8Array.
+   * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
+   * @throws {Error} - If the public key is null or undefined.
+   */
+  publicKey(publicKey: Nillable<HexString | Uint8Array>): NonNil<PayloadBuilder> {
+    // throw runtime error if public key is null or undefined
+    let key = objects.requireNonNil(publicKey, 'public key is required to build a transaction.');
+
+    // if near is string, convert to hex
+    if (typeof key === 'string') {
+      // accept near keys in their native format: ed25519:<base-58>
+      if (isNearPubKey(key)) {
+        key = nearB58ToHex(key);
+      }
+
+      // convert hex string to bytes
+      key = hexToBytes(key);
     }
 
-    /**
-     * Creates a new `PayloadBuilder` instance.
-     * 
-     * @param {Kwil} client - The Kwil client, used to call higher level methods on the Kwil class.
-     * @returns {PayloadBuilder} - A new `PayloadBuilder` instance.
-     */
-    public static of(client: NonNil<Kwil>): NonNil<PayloadBuilder> {
-        return new PayloadBuilderImpl(client);
+    this._publicKey = key;
+
+    return this;
+  }
+
+  /**
+   * Set the description to be included in the payload signature.
+   *
+   * @param {string | null} description - The description to be included in the payload signature.
+   * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
+   */
+  description(description: Nillable<string>): NonNil<PayloadBuilder> {
+    // assign description if it is not null or undefined
+    // we do not want to throw an error if null because description is optional. The default value is empty string.
+    if (description) {
+      this._description = description;
+    }
+    return this;
+  }
+
+  /**
+   * Specifies the chain ID for the network being used.
+   *
+   * @param {string} chainId - The chain ID for the network being used.
+   * @returns {PayloadBuilder} The current `PayloadBuilder` instance for chaining.
+   */
+  chainId(chainId: string): NonNil<PayloadBuilder> {
+    this._chainId = objects.requireNonNil(
+        chainId,
+        'chain ID is required to build a transaction.'
+    );
+    return this;
+  };
+
+  /**
+   * Builds the payload for the `kwil.broadcast()` method (i.e. the broadcast GRPC endpoint - see {@link https://github.com/kwilteam/proto/blob/main/kwil/tx/v1/tx.proto})
+   *
+   * @returns {BaseTransaction} - A promise that resolves to the signed transaction.
+   * @throws {Error} - If the required fields in the builder are null or undefined.
+   */
+  async buildTx(): Promise<Transaction> {
+    // complete lazy evaluation of payload
+    const resolvedPayload = await this.resolvePayload();
+
+    // ensure required fields are not null or undefined
+    const signer = objects.requireNonNil(
+      this._signer,
+      'signer is required to build a transaction.'
+    );
+    const payloadType = objects.requireNonNil(
+      this._payloadType,
+      'payload type is required to build a transaction.'
+    );
+    const publicKey = objects.requireNonNil(
+      this._publicKey,
+      'public key is required to build a transaction. Please chain the .publicKey() method to your builder.'
+    );
+    const signatureType = objects.requireNonNil(
+      this._signatureType,
+      'signature type is required to build a transaction.'
+    );
+    const chainId = objects.requireNonNil(
+        this._chainId,
+        'chain ID is required to build a transaction.'
+    );
+
+    // create transaction payload for estimating cost. Set the Tx bytes type to base64 encoded because we need to make GRPC estimate cost request.
+    const preEstTxn = Txn.create<BytesEncodingStatus.BASE64_ENCODED>((tx) => {
+      // rlp encode the payload and convert to base64
+      tx.body.payload = bytesToBase64(kwilEncode(resolvedPayload));
+      tx.body.payload_type = payloadType;
+    });
+
+    // estimate the cost of the transaction with the estimateCost symbol from the client
+    const cost = await unwrap(this.client)(preEstTxn);
+
+    // retrieve the account for the nonce
+    const acct = await this.client.getAccount(publicKey);
+
+    // add the nonce and fee to the transaction. Set the tx bytes back to uint8 so we can do the signature.
+    const postEstTxn = Txn.copy<BytesEncodingStatus.UINT8_ENCODED>(preEstTxn, (tx) => {
+      tx.body.payload = base64ToBytes(preEstTxn.body.payload as string);
+      tx.body.fee = BigInt(
+        strings.requireNonNil(
+          cost.data,
+          'something went wrong estimating the cost of your transaction.'
+        )
+      );
+      tx.body.nonce =
+        Number(
+          objects.requireNonNil(
+            acct.data?.nonce,
+            'something went wrong retrieving your account nonce.'
+          )
+        ) + 1;
+        tx.body.chain_id = chainId;
+    });
+
+    // check that a valid signature is used
+    if (signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
+      throw new Error('Signature type is invalid.');
     }
 
-    /**
-     * Specify the payload type to be built.
-     * 
-     * @param {PayloadType} payloadType - The payload type to be built. See {@link PayloadType} for more information.
-     * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
-     * @throws {Error} - If the payload type is null or undefined.
-     */
-    payloadType(payloadType: NonNil<PayloadType>): PayloadBuilder {
-        // throw runtime error if payload type is null or undefined
-        this._payloadType = objects.requireNonNil(payloadType, "payload type is required to build a transaction.");
-        return this;
+    return PayloadBuilderImpl.signTx(
+      postEstTxn,
+      signer,
+      publicKey,
+      signatureType,
+      this._description
+    );
+  }
+
+  /**
+   * Build the payload structure for message to the `kwil.call()` method (i.e. the call GRPC endpoint - see {@link https://github.com/kwilteam/proto/blob/main/kwil/tx/v1/call.proto})
+   *
+   * @returns {Message} - A promise that resolves to the built message, with signature if provided.
+   * @throws {Error} - If the required fields in the builder are null or undefined.
+   */
+  async buildMsg(): Promise<Message> {
+    // complete lazy evaluation of payload
+    const resolvedPayload = await this.resolvePayload();
+
+    // create the msg object with the payload, with the payload bytes type set to uint8 for RLP encoding.
+    let msg = Msg.create<BytesEncodingStatus.UINT8_ENCODED>((msg) => {
+      msg.body.payload = resolvedPayload as UnencodedActionPayload<PayloadType.CALL_ACTION>;
+    });
+
+    // if a signer has been provided, execute a signed `view` action
+    if (this._signer) {
+      // ensure required fields are provided in the builder
+      const publicKey = objects.requireNonNil(
+        this._publicKey,
+        'public key is required to build a message that uses a signer.'
+      );
+      const signatureType = objects.requireNonNil(
+        this._signatureType,
+        'signature type is required to build a signed message.'
+      );
+
+      // ensure a valid signature type is used
+      if (this._signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
+        throw new Error('Signature type is invalid.');
+      }
+
+      // sign the message
+      return await PayloadBuilderImpl.signMsg(
+        msg,
+        this._signer,
+        publicKey,
+        signatureType,
+        this._description
+      );
     }
 
-    /**
-     * Specify the signer and the signature type.
-     * 
-     * @param {SignerSupplier} signer - The signer to be used to sign the transaction.
-     * @param {AnySignatureType} sigType - The signature type to be used to sign the transaction. See {@link SignatureType} for more information.
-     * @returns The current `PayloadBuilder` instance for chaining.
-     * @throws {Error} - If the signer is null or undefined.
-     * @throws {Error} - If the signature type is null or undefined.
-     */
-    signer(signer: SignerSupplier, sigType: AnySignatureType): NonNil<PayloadBuilder> {
-        // throw runtime errors if signer or signature type are null or undefined
-        this._signer = objects.requireNonNil(signer);
-        this._signatureType = objects.requireNonNil(sigType, "signature type is required to build a transaction.");
-        return this;
-    }
+    // return the unsigned message, with the payload base64 encoded
+    return Msg.copy<BytesEncodingStatus.BASE64_ENCODED>(msg, (msg) => {
+      // rlp encode the payload and convert to base64 for transport over GRPC
+      msg.body.payload = bytesToBase64(kwilEncode(resolvedPayload));
+    });
+  }
 
-    /**
-     * Sets the content for the body of the payload object.
-     * 
-     * @param {() => NonNil<AllPayloads> | NonNil<AllPayloads>} payload - The payload to be built. This can be a function that returns an object or an object.
-     * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
-     * @throws {Error} - If the payload is null or undefined.
-     */
-    payload(payload: (() => NonNil<AllPayloads>) | NonNil<AllPayloads>): NonNil<PayloadBuilder> {
-        // throw runtime error if payload is null or undefined
-        const ensuredPayload = objects.requireNonNil(payload, "transaction payload cannot be null.");
+  /**
+   * Execute lazy evaluation of payload.
+   *
+   * @returns {AllPayloads} - A promise that resolves to the provided payload object.
+   */
+  private async resolvePayload(): Promise<AllPayloads> {
+    const payloadFn = objects.requireNonNil(
+      this._payload,
+      'payload is required to build the payload.'
+    );
 
-        // ensure payload is a function for lazy evaluation
-        this._payload = typeof ensuredPayload !== "function" ?
-            () => ensuredPayload :
-            ensuredPayload as () => NonNil<AllPayloads>;
+    const resolvedPayload = objects.requireNonNil(
+      payloadFn(),
+      'payload cannot resolve to be null.'
+    );
 
-        return this;
-    }
+    return resolvedPayload;
+  }
 
-    /**
-     * Specify the public key for the payload signer.
-     * 
-     * @param {HexString | Uint8Array} publicKey - The public key to be used to sign the transaction. This can be a hex string or a Uint8Array.
-     * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
-     * @throws {Error} - If the public key is null or undefined.
-     */
-    publicKey(publicKey: Nillable<HexString | Uint8Array>): NonNil<PayloadBuilder> {
-        // throw runtime error if public key is null or undefined
-        let key = objects.requireNonNil(publicKey, "public key is required to build a transaction.");
+  /**
+   * Signs the payload of a transaction / request to the broadcast GRPC endpoint.
+   *
+   * @param {BaseTransaction} tx - The transaction to sign. See {@link BaseTransaction} for more information.
+   * @param {SignerSupplier} signer - The signer to be used to sign the transaction.
+   * @param {Uint8Array} pubKey - The public key for the signature, represented as bytes.
+   * @param {AnySignatureType} signatureType - The signature type being used. See {@link SignatureType} for more information.
+   * @param {string} description - The description to be included in the signature.
+   * @returns {BaseTransaction} - A promise that resolves to the signed transaction.
+   * @throws {Error} - If the the signer is not an Ethers Signer or a function that accepts and returns a Uint8Array.
+   */
+  private static async signTx(
+    tx: BaseTransaction<BytesEncodingStatus.UINT8_ENCODED>,
+    signer: SignerSupplier,
+    pubKey: Uint8Array,
+    signatureType: AnySignatureType,
+    description: string
+  ): Promise<Transaction> {
+    // create the digest, which is the first bytes of the sha256 hash of the rlp-encoded payload
+    const digest = sha256BytesToBytes(tx.body.payload as Uint8Array).subarray(0, 20);
 
-        // if near is string, convert to hex
-        if(typeof key === "string") {
-            // accept near keys in their native format: ed25519:<base-58>
-            if(isNearPubKey(key)) {
-                key = nearB58ToHex(key);
-            }
-
-            // convert hex string to bytes
-            key = hexToBytes(key);
-        }
-
-        this._publicKey = key;
-
-        return this;
-    }
-
-    /**
-     * Set the description to be included in the payload signature.
-     * 
-     * @param {string | null} description - The description to be included in the payload signature.
-     * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
-     */
-    description(description: Nillable<string>): NonNil<PayloadBuilder> {
-        // assign description if it is not null or undefined
-        // we do not want to throw an error if null because description is optional. The default value is empty string.
-        if(description) {
-            this._description = description;
-        }
-        return this;
-    }
-
-    /**
-     * Builds the payload for the `kwil.broadcast()` method (i.e. the broadcast GRPC endpoint - see {@link https://github.com/kwilteam/proto/blob/main/kwil/tx/v1/tx.proto})
-     * 
-     * @returns {BaseTransaction} - A promise that resolves to the signed transaction.
-     * @throws {Error} - If the required fields in the builder are null or undefined.
-     */
-    async buildTx(): Promise<Transaction> {
-        // complete lazy evaluation of payload
-        const resolvedPayload = await this.resolvePayload();
-
-        // ensure required fields are not null or undefined
-        const signer = objects.requireNonNil(this._signer, "signer is required to build a transaction.")
-        const payloadType = objects.requireNonNil(this._payloadType, "payload type is required to build a transaction.");
-        const publicKey = objects.requireNonNil(this._publicKey, "public key is required to build a transaction. Please chain the .publicKey() method to your builder.");
-        const signatureType = objects.requireNonNil(this._signatureType, "signature type is required to build a transaction.");
-
-        // create transaction payload for estimating cost. Set the Tx bytes type to base64 encoded because we need to make GRPC estimate cost request.
-        const preEstTxn = Txn.create<BytesEncodingStatus.BASE64_ENCODED>(tx => {
-            // rlp encode the payload and convert to base64
-            tx.body.payload = bytesToBase64(kwilEncode(resolvedPayload));
-            tx.body.payload_type = payloadType;
-        });
-
-        // estimate the cost of the transaction with the estimateCost symbol from the client
-        const cost = await unwrap(this.client)(preEstTxn);
-
-        // retrieve the account for the nonce
-        const acct = await this.client.getAccount(publicKey);
-        
-        // add the nonce and fee to the transaction. Set the tx bytes back to uint8 so we can do the signature.
-        const postEstTxn = Txn.copy<BytesEncodingStatus.UINT8_ENCODED>(preEstTxn, tx => {
-            tx.body.payload = base64ToBytes(preEstTxn.body.payload as string);
-            tx.body.fee = BigInt(strings.requireNonNil(cost.data, 'something went wrong estimating the cost of your transaction.'));
-            tx.body.nonce = Number(objects.requireNonNil(acct.data?.nonce, 'something went wrong retrieving your account nonce.')) + 1;
-        })
-
-        // check that a valid signature is used
-        if(signatureType=== SignatureType.SIGNATURE_TYPE_INVALID) {
-            throw new Error("Signature type is invalid.");
-        }
-
-        return PayloadBuilderImpl.signTx(postEstTxn, signer, publicKey, signatureType, this._description);
-    }
-
-    /**
-     * Build the payload structure for message to the `kwil.call()` method (i.e. the call GRPC endpoint - see {@link https://github.com/kwilteam/proto/blob/main/kwil/tx/v1/call.proto})
-     * 
-     * @returns {Message} - A promise that resolves to the built message, with signature if provided.
-     * @throws {Error} - If the required fields in the builder are null or undefined.
-     */
-    async buildMsg(): Promise<Message> {
-        // complete lazy evaluation of payload
-        const resolvedPayload = await this.resolvePayload();
-
-        // create the msg object with the payload, with the payload bytes type set to uint8 for RLP encoding.
-        let msg = Msg.create<BytesEncodingStatus.UINT8_ENCODED>(msg => {
-            msg.body.payload = resolvedPayload as UnencodedActionPayload<PayloadType.CALL_ACTION>;
-        });
-
-        // if a signer has been provided, execute a signed `view` action
-        if(this._signer) {
-            // ensure required fields are provided in the builder
-            const publicKey = objects.requireNonNil(this._publicKey, 'public key is required to build a message that uses a signer.')
-            const signatureType = objects.requireNonNil(this._signatureType, 'signature type is required to build a signed message.')
-
-            // ensure a valid signature type is used
-            if(this._signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
-                throw new Error("Signature type is invalid.");
-            }
-
-            // sign the message
-            return await PayloadBuilderImpl.signMsg(msg, this._signer, publicKey, signatureType, this._description);
-        }
-
-        // return the unsigned message, with the payload base64 encoded
-        return Msg.copy<BytesEncodingStatus.BASE64_ENCODED>(msg, msg => {
-            // rlp encode the payload and convert to base64 for transport over GRPC
-            msg.body.payload = bytesToBase64(kwilEncode(resolvedPayload));
-        });
-    }
-
-    /**
-     * Execute lazy evaluation of payload.
-     * 
-     * @returns {AllPayloads} - A promise that resolves to the provided payload object.
-     */
-    private async resolvePayload(): Promise<AllPayloads> {
-        const payloadFn = objects.requireNonNil(this._payload, "payload is required to build the payload.");
-
-        const resolvedPayload = objects.requireNonNil(payloadFn(), "payload cannot resolve to be null.");
-
-        return resolvedPayload
-    }
-
-    /**
-     * Signs the payload of a transaction / request to the broadcast GRPC endpoint.
-     * 
-     * @param {BaseTransaction} tx - The transaction to sign. See {@link BaseTransaction} for more information.
-     * @param {SignerSupplier} signer - The signer to be used to sign the transaction.
-     * @param {Uint8Array} pubKey - The public key for the signature, represented as bytes.
-     * @param {AnySignatureType} signatureType - The signature type being used. See {@link SignatureType} for more information.
-     * @param {string} description - The description to be included in the signature.
-     * @returns {BaseTransaction} - A promise that resolves to the signed transaction.
-     * @throws {Error} - If the the signer is not an Ethers Signer or a function that accepts and returns a Uint8Array.
-     */
-    private static async signTx(tx: BaseTransaction<BytesEncodingStatus.UINT8_ENCODED>, signer: SignerSupplier, pubKey: Uint8Array, signatureType: AnySignatureType, description: string): Promise<Transaction> {
-        // create salt
-        const salt = generateSalt(16);
-
-        // create the digest, which is the first bytes of the sha256 hash of the rlp-encoded payload
-        const digest = sha256BytesToBytes(tx.body.payload as Uint8Array).subarray(0, 20);
-
-        // create the signature message
-        const signatureMessage = `${description}
+    // create the signature message
+    const signatureMessage = `${description}
 
 PayloadType: ${tx.body.payload_type}
 PayloadDigest: ${bytesToHex(digest)}
 Fee: ${tx.body.fee}
 Nonce: ${tx.body.nonce}
-Salt: ${bytesToHex(salt)}
+Chain ID: ${tx.body.chain_id}
 
 Kwil 🖋
-`
+`;
 
-        // sign the above message
-        const signedMessage = await executeSign(stringToBytes(signatureMessage), signer, signatureType);
+    // sign the above message
+    const signedMessage = await executeSign(stringToBytes(signatureMessage), signer, signatureType);
 
-        // copy the transaction and add the signature
-        return Txn.copy<BytesEncodingStatus.BASE64_ENCODED>(tx, (newTx) => {
-            newTx.signature = {
-                // bytes must be base64 encoded for transport over GRPC
-                signature_bytes: bytesToBase64(signedMessage),
-                signature_type: signatureType.toString() as SignatureType
-            };
-            newTx.body = {
-                description: description,
-                payload: bytesToBase64(tx.body.payload as Uint8Array),
-                payload_type: newTx.body.payload_type as PayloadType,
-                fee: newTx.body.fee?.toString(),
-                nonce: newTx.body.nonce,
-                // bytes must be base64 encoded for transport over GRPC
-                salt: bytesToBase64(salt),
-            };
-            // bytes must be base64 encoded for transport over GRPC
-            newTx.sender = bytesToBase64(pubKey);
-            newTx.serialization = SerializationType.SIGNED_MSG_CONCAT;
-        });
+    // copy the transaction and add the signature
+    return Txn.copy<BytesEncodingStatus.BASE64_ENCODED>(tx, (newTx) => {
+      newTx.signature = {
+        // bytes must be base64 encoded for transport over GRPC
+        signature_bytes: bytesToBase64(signedMessage),
+        signature_type: signatureType.toString() as SignatureType,
+      };
+      newTx.body = {
+        description: description,
+        payload: bytesToBase64(tx.body.payload as Uint8Array),
+        payload_type: newTx.body.payload_type as PayloadType,
+        fee: newTx.body.fee?.toString(),
+        nonce: newTx.body.nonce,
+        chain_id: newTx.body.chain_id,
+      };
+      // bytes must be base64 encoded for transport over GRPC
+      newTx.sender = bytesToBase64(pubKey);
+      newTx.serialization = SerializationType.SIGNED_MSG_CONCAT;
+    });
+  }
+
+  /**
+   * Signs the payload of a `view action` / call request to the call GRPC endpoint.
+   *
+   * @param {Message} msg - The message to sign. See {@link Message} for more information.
+   * @param {SignerSupplier} signer - The signer to be used to sign the message.
+   * @param {Uint8Array} pubKey - The public key for the signature, represented as bytes.
+   * @param {AnySignatureType} signatureType - The signature type being used. See {@link SignatureType} for more information.
+   * @param {string} description - The description to be included in the signature.
+   * @returns Message - A promise that resolves to the signed message.
+   * @throws {Error} - If the the signer is not an Ethers Signer or a function that accepts and returns a Uint8Array.
+   */
+  private static async signMsg(
+    msg: BaseMessage<BytesEncodingStatus.UINT8_ENCODED>,
+    signer: SignerSupplier,
+    pubKey: Uint8Array,
+    signatureType: AnySignatureType,
+    description: string
+  ): Promise<Message> {
+    // ensure that the payload is not already base64 encoded
+    if (typeof msg.body.payload === 'string') {
+      throw new Error('Payload must be an object to sign a message.');
     }
 
-    /**
-     * Signs the payload of a `view action` / call request to the call GRPC endpoint.
-     * 
-     * @param {Message} msg - The message to sign. See {@link Message} for more information. 
-     * @param {SignerSupplier} signer - The signer to be used to sign the message.
-     * @param {Uint8Array} pubKey - The public key for the signature, represented as bytes.
-     * @param {AnySignatureType} signatureType - The signature type being used. See {@link SignatureType} for more information.
-     * @param {string} description - The description to be included in the signature. 
-     * @returns Message - A promise that resolves to the signed message.
-     * @throws {Error} - If the the signer is not an Ethers Signer or a function that accepts and returns a Uint8Array.
-     */
-    private static async signMsg(msg: BaseMessage<BytesEncodingStatus.UINT8_ENCODED>, signer: SignerSupplier, pubKey: Uint8Array, signatureType: AnySignatureType, description: string): Promise<Message> {
-        // ensure that the payload is not already base64 encoded
-        if(typeof msg.body.payload === "string") {
-            throw new Error("Payload must be an object to sign a message.");
-        }
+    // rlp encode the payload
+    const encodedPayload = kwilEncode(
+      msg.body.payload as UnencodedActionPayload<PayloadType.CALL_ACTION>
+    );
 
-        // rlp encode the payload
-        const encodedPayload = kwilEncode(msg.body.payload as UnencodedActionPayload<PayloadType.CALL_ACTION>);
+    // create the digest, which is the first bytes of the sha256 hash of the rlp-encoded payload
+    const digest = sha256BytesToBytes(encodedPayload).subarray(0, 20);
 
-        // create the digest, which is the first bytes of the sha256 hash of the rlp-encoded payload
-        const digest = sha256BytesToBytes(encodedPayload).subarray(0, 20);
-
-        // create the signature message
-        const signatureMessage = `${description}
+    // create the signature message
+    const signatureMessage = `${description}
 
 DBID: ${msg.body.payload?.dbid}
 Action: ${msg.body.payload?.action}
 PayloadDigest: ${bytesToHex(digest)}
 
 Kwil 🖋
-`
-        // sign the above message
-        const signedMessage = await executeSign(stringToBytes(signatureMessage), signer, signatureType);
+`;
+    // sign the above message
+    const signedMessage = await executeSign(stringToBytes(signatureMessage), signer, signatureType);
 
-        // copy the message and add the signature, with bytes set to base64 for transport over GRPC
-        return Msg.copy<BytesEncodingStatus.BASE64_ENCODED>(msg, (msg) => {
-            // bytes must be base64 encoded for transport over GRPC
-            msg.body.payload = bytesToBase64(encodedPayload);
-            msg.body.description = description;
-            msg.signature = {
-                // bytes must be base64 encoded for transport over GRPC
-                signature_bytes: bytesToBase64(signedMessage),
-                signature_type: signatureType.toString() as SignatureType
-            };
-            // bytes must be base64 encoded for transport over GRPC
-            msg.sender = bytesToBase64(pubKey);
-            msg.serialization = SerializationType.SIGNED_MSG_CONCAT;
-        })
-    }
+    // copy the message and add the signature, with bytes set to base64 for transport over GRPC
+    return Msg.copy<BytesEncodingStatus.BASE64_ENCODED>(msg, (msg) => {
+      // bytes must be base64 encoded for transport over GRPC
+      msg.body.payload = bytesToBase64(encodedPayload);
+      msg.body.description = description;
+      msg.signature = {
+        // bytes must be base64 encoded for transport over GRPC
+        signature_bytes: bytesToBase64(signedMessage),
+        signature_type: signatureType.toString() as SignatureType,
+      };
+      // bytes must be base64 encoded for transport over GRPC
+      msg.sender = bytesToBase64(pubKey);
+      msg.serialization = SerializationType.SIGNED_MSG_CONCAT;
+    });
+  }
 }

--- a/src/client/kwil.ts
+++ b/src/client/kwil.ts
@@ -1,316 +1,360 @@
-import { generateDBID } from "../utils/dbid";
-import Client from "../api_client/client";
-import { Config } from "../api_client/config";
-import {GenericResponse} from "../core/resreq";
-import {Database, DeployBody, DropBody, SelectQuery} from "../core/database";
-import {BaseTransaction, Transaction, TxReceipt} from "../core/tx";
-import {Account} from "../core/account";
-import {ActionBuilderImpl} from "../builders/action_builder";
-import {base64ToBytes} from "../utils/base64";
-import {DBBuilderImpl} from "../builders/db_builder";
-import {NonNil} from "../utils/types";
-import {ActionBuilder, DBBuilder} from "../core/builders";
-import {wrap} from "./intern";
-import { Cache } from "../utils/cache";
-import { TxInfoReceipt } from "../core/txQuery";
-import { BaseMessage, Message, MsgReceipt } from "../core/message";
-import { BytesEncodingStatus, PayloadType } from "../core/enums";
-import { hexToBytes } from "../utils/serial";
-import { isNearPubKey, nearB58ToHex } from "../utils/keys";
-import { ActionBody, ActionInput, Entries, resolveActionInputs } from "../core/action";
-import { KwilSigner } from "../core/kwilSigner";
+import { generateDBID } from '../utils/dbid';
+import Client from '../api_client/client';
+import { ApiConfig, Config } from '../api_client/config';
+import { GenericResponse } from '../core/resreq';
+import { Database, DeployBody, DropBody, SelectQuery } from '../core/database';
+import { BaseTransaction, TxReceipt } from '../core/tx';
+import { Account, ChainInfo } from '../core/network';
+import { ActionBuilderImpl } from '../builders/action_builder';
+import { base64ToBytes } from '../utils/base64';
+import { DBBuilderImpl } from '../builders/db_builder';
+import { NonNil } from '../utils/types';
+import { ActionBuilder, DBBuilder } from '../core/builders';
+import { wrap } from './intern';
+import { Cache } from '../utils/cache';
+import { TxInfoReceipt } from '../core/txQuery';
+import { BaseMessage, Message, MsgReceipt } from '../core/message';
+import { BytesEncodingStatus, PayloadType } from '../core/enums';
+import { hexToBytes } from '../utils/serial';
+import { isNearPubKey, nearB58ToHex } from '../utils/keys';
+import { ActionBody, ActionInput, Entries, resolveActionInputs } from '../core/action';
+import { KwilSigner } from '../core/kwilSigner';
 
 /**
  * The main class for interacting with the Kwil network.
  */
 
 export abstract class Kwil {
-    private readonly client: Client;
-    //cache schemas
-    private schemas: Cache<GenericResponse<Database>>;
+  private readonly client: Client;
+  private readonly chainId: string;
+  //cache schemas
+  private schemas: Cache<GenericResponse<Database>>;
 
-    protected constructor(opts: Config) {
-        this.client = new Client({
-            kwilProvider: opts.kwilProvider,
-            apiKey: opts.apiKey,
-            network: opts.network,
-            timeout: opts.timeout,
-            logging: opts.logging,
-            logger: opts.logger,
-            cache: opts.cache,
-        });
+  protected constructor(opts: Config) {
+    this.client = new Client({
+      kwilProvider: opts.kwilProvider,
+      apiKey: opts.apiKey,
+      network: opts.network,
+      timeout: opts.timeout,
+      logging: opts.logging,
+      logger: opts.logger,
+      cache: opts.cache,
+    });
 
-        this.schemas = Cache.passive(opts.cache);
+    this.schemas = Cache.passive(opts.cache);
 
-        //create a wrapped symbol of estimateCost method
-        wrap(this, this.client.estimateCost.bind(this.client));
+    // set chainId
+    this.chainId = opts.chainId;
+
+    //create a wrapped symbol of estimateCost method
+    wrap(this, this.client.estimateCost.bind(this.client));
+  }
+
+  /**
+   * Generates a unique database identifier (DBID) from the provided owner's public key and a database name.
+   *
+   * @param owner - The owner's public key (Ethereum or NEAR Protocol). Ethereum keys can be passed as a hex string (0x123...) or as bytes (Uint8Array). NEAR protocol public keys can be passed as the base58 encoded public key (with "ed25519:" prefix), a hex string, or bytes (Uint8Array).
+   * @param name - The name of the database. This should be a unique name to identify the database.
+   * @returns A string that represents the unique identifier for the database.
+   */
+
+  public getDBID(owner: string | Uint8Array, name: string): string {
+    return generateDBID(owner, name);
+  }
+
+  /**
+   * Retrieves the schema of a database given its unique identifier (DBID).
+   *
+   * @param dbid - The unique identifier of the database. The DBID can be generated using the kwil.getDBID method.
+   * @returns A promise that resolves to the schema of the database.
+   */
+
+  public async getSchema(dbid: string): Promise<GenericResponse<Database>> {
+    // check cache
+    const schema = this.schemas.get(dbid);
+    if (schema) {
+      return schema;
     }
 
-    /**
-     * Generates a unique database identifier (DBID) from the provided owner's public key and a database name.
-     *
-     * @param owner - The owner's public key (Ethereum or NEAR Protocol). Ethereum keys can be passed as a hex string (0x123...) or as bytes (Uint8Array). NEAR protocol public keys can be passed as the base58 encoded public key (with "ed25519:" prefix), a hex string, or bytes (Uint8Array).
-     * @param name - The name of the database. This should be a unique name to identify the database.
-     * @returns A string that represents the unique identifier for the database.
-     */
+    //fetch from server
+    const res = await this.client.getSchema(dbid);
 
-    public getDBID(owner: string | Uint8Array, name: string): string {
-        return generateDBID(owner, name);
+    //cache result
+    if (res.status === 200) {
+      this.schemas.set(dbid, res);
     }
 
-    /**
-     * Retrieves the schema of a database given its unique identifier (DBID).
-     *
-     * @param dbid - The unique identifier of the database. The DBID can be generated using the kwil.getDBID method.
-     * @returns A promise that resolves to the schema of the database. 
-     */
+    return res;
+  }
 
-    public async getSchema(dbid: string): Promise<GenericResponse<Database>> {
-        // check cache
-        const schema = this.schemas.get(dbid)
-        if (schema) {
-            return schema;
-        }
+  /**
+   * Retrieves an account using the owner's Ethereum wallet address.
+   *
+   * @param owner - The owner's public key (Ethereum or NEAR Protocol). Ethereum keys can be passed as a hex string (0x123...) or as bytes (Uint8Array). NEAR protocol public keys can be passed as the base58 encoded public key (with "ed25519:" prefix), a hex string, or bytes (Uint8Array).
+   * @returns A promise that resolves to an Account object. The account object includes the owner's public key, balance, and nonce.
+   */
 
-        //fetch from server
-        const res = await this.client.getSchema(dbid);
+  public async getAccount(owner: string | Uint8Array): Promise<GenericResponse<Account>> {
+    if (typeof owner === 'string') {
+      if (isNearPubKey(owner)) {
+        owner = nearB58ToHex(owner);
+      }
 
-        //cache result
-        if (res.status === 200) {
-            this.schemas.set(dbid, res);
-        }
-
-        return res;
+      owner = owner.toLowerCase();
+      owner = hexToBytes(owner);
     }
 
-    /**
-     * Retrieves an account using the owner's Ethereum wallet address.
-     *
-     * @param owner - The owner's public key (Ethereum or NEAR Protocol). Ethereum keys can be passed as a hex string (0x123...) or as bytes (Uint8Array). NEAR protocol public keys can be passed as the base58 encoded public key (with "ed25519:" prefix), a hex string, or bytes (Uint8Array).
-     * @returns A promise that resolves to an Account object. The account object includes the owner's public key, balance, and nonce.
-     */
+    return await this.client.getAccount(owner);
+  }
 
-    public async getAccount(owner: string | Uint8Array): Promise<GenericResponse<Account>> {
-        if(typeof owner === 'string') {
-            if(isNearPubKey(owner)) {
-                owner = nearB58ToHex(owner);
-            }
+  /**
+   * Returns an instance of ActionBuilder for this client.
+   *
+   * @returns An ActionBuilder instance. ActionBuilder is used to build action transactions to be broadcasted to the Kwil network.
+   */
 
-            owner = owner.toLowerCase();
-            owner = hexToBytes(owner);
-        }
-        
-        return await this.client.getAccount(owner);
+  public actionBuilder(): NonNil<ActionBuilder> {
+    return ActionBuilderImpl.of(this).chainId(this.chainId);
+  }
+
+  /**
+   * Returns an instance of DBBuilder for this client.
+   *
+   * @returns A DBBuilder instance. DBBuilder is used to build new database transactions to be broadcasted to the Kwil network.
+   */
+
+  public dbBuilder(): NonNil<DBBuilder<PayloadType.DEPLOY_DATABASE>> {
+    return DBBuilderImpl.of<PayloadType.DEPLOY_DATABASE>(this, PayloadType.DEPLOY_DATABASE).chainId(this.chainId);
+  }
+
+  /**
+   * Returns an instance of Drop Database Builder for this client.
+   *
+   * @returns A Drop Database Builder instance. Drop Database Builder is used to build drop database transactions to be broadcasted to the Kwil network.
+   */
+
+  public dropDbBuilder(): NonNil<DBBuilder<PayloadType.DROP_DATABASE>> {
+    return DBBuilderImpl.of<PayloadType.DROP_DATABASE>(this, PayloadType.DROP_DATABASE).chainId(this.chainId);
+  }
+
+  /**
+   * Broadcasts a transaction on the network.
+   *
+   * @param tx - The transaction to broadcast. The transaction can be built using the ActionBuilder or DBBuilder.
+   * @returns A promise that resolves to the receipt of the transaction. The transaction receipt includes the transaction hash, fee, and body.
+   */
+
+  public async broadcast(
+    tx: BaseTransaction<BytesEncodingStatus.BASE64_ENCODED>
+  ): Promise<GenericResponse<TxReceipt>> {
+    return await this.client.broadcast(tx);
+  }
+
+  /**
+   * Executes a transaction on a Kwil network. These are mutative actions that must be mined on the Kwil network's blockchain.
+   *
+   * @param actionBody - The body of the action to send. This should use the `ActionBody` interface.
+   * @param kwilSigner - The signer for the action transactions.
+   * @returns A promise that resolves to the receipt of the transaction.
+   */
+  public async execute(
+    actionBody: ActionBody,
+    kwilSigner: KwilSigner
+  ): Promise<GenericResponse<TxReceipt>> {
+    let tx = ActionBuilderImpl.of(this)
+      .dbid(actionBody.dbid)
+      .name(actionBody.action)
+      .description(actionBody.description || '')
+      .publicKey(kwilSigner.publicKey)
+      .chainId(this.chainId)
+      .signer(kwilSigner.signer, kwilSigner.signatureType);
+
+    if (actionBody.inputs) {
+      const inputs = resolveActionInputs(actionBody.inputs);
+
+      tx = tx.concat(inputs);
     }
 
-    /**
-     * Returns an instance of ActionBuilder for this client.
-     *
-     * @returns An ActionBuilder instance. ActionBuilder is used to build action transactions to be broadcasted to the Kwil network.
-     */  
+    const transaction = await tx.buildTx();
 
-    public actionBuilder(): NonNil<ActionBuilder> {
-        return ActionBuilderImpl.of(this);
+    return await this.client.broadcast(transaction);
+  }
+
+  /**
+   * Deploys a database to the Kwil network.
+   *
+   * @param deployBody - The body of the database to deploy. This should use the `DeployBody` interface.
+   * @param kwilSigner - The signer for the database deployment.
+   * @returns A promise that resolves to the receipt of the transaction.
+   */
+  public async deploy(
+    deployBody: DeployBody,
+    kwilSigner: KwilSigner
+  ): Promise<GenericResponse<TxReceipt>> {
+    const tx = await DBBuilderImpl.of<PayloadType.DEPLOY_DATABASE>(
+      this,
+      PayloadType.DEPLOY_DATABASE
+    )
+      .description(deployBody.description || '')
+      .payload(deployBody.schema)
+      .publicKey(kwilSigner.publicKey)
+      .signer(kwilSigner.signer, kwilSigner.signatureType)
+      .chainId(this.chainId)
+      .buildTx();
+
+    return await this.client.broadcast(tx);
+  }
+
+  /**
+   * Drops a database from the Kwil network.
+   *
+   * @param dropBody - The body of the database to drop. This should use the `DropBody` interface.
+   * @param kwilSigner - The signer for the database drop.
+   * @returns A promise that resolves to the receipt of the transaction.
+   */
+  public async drop(
+    dropBody: DropBody,
+    kwilSigner: KwilSigner
+  ): Promise<GenericResponse<TxReceipt>> {
+    const tx = await DBBuilderImpl.of<PayloadType.DROP_DATABASE>(this, PayloadType.DROP_DATABASE)
+      .description(dropBody.description || '')
+      .payload({ dbid: dropBody.dbid })
+      .publicKey(kwilSigner.publicKey)
+      .signer(kwilSigner.signer, kwilSigner.signatureType)
+      .chainId(this.chainId)
+      .buildTx();
+
+    return await this.client.broadcast(tx);
+  }
+
+  /**
+   * Calls a Kwil node. This can be used to execute read-only ('view') actions on Kwil.
+   *
+   * @param actionBody - The body of the action to send. This should use the `ActionBody` interface.
+   * @param kwilSigner (optional) - The signer for the action call, if required. Signers are only required for actions with a `must_sign` attribute. You can check the attributes on an action by calling `kwil.getSchema(dbid)`.
+   * @returns A promise that resolves to the receipt of the message.
+   */
+  public async call(
+    actionBody: ActionBody,
+    kwilSigner?: KwilSigner
+  ): Promise<GenericResponse<MsgReceipt>>;
+
+  /**
+   * Calls a Kwil node. This can be used to execute read-only ('view') actions on Kwil.
+   *
+   * @param actionBody - The message to send. The message can be built using the ActionBuilder class.
+   * @returns A promise that resolves to the receipt of the message.
+   */
+  public async call(actionBody: Message): Promise<GenericResponse<MsgReceipt>>;
+
+  public async call(
+    actionBody: Message | ActionBody,
+    kwilSigner?: KwilSigner
+  ): Promise<GenericResponse<MsgReceipt>> {
+    if (actionBody instanceof BaseMessage) {
+      return await this.client.call(actionBody);
     }
 
-    /**
-     * Returns an instance of DBBuilder for this client.
-     *
-     * @returns A DBBuilder instance. DBBuilder is used to build new database transactions to be broadcasted to the Kwil network.
-     */
+    let msg = this.actionBuilder()
+      .dbid(actionBody.dbid)
+      .name(actionBody.action)
+      .description(actionBody.description || '');
 
-    public dbBuilder(): NonNil<DBBuilder<PayloadType.DEPLOY_DATABASE>> {
-        return DBBuilderImpl.of<PayloadType.DEPLOY_DATABASE>(this, PayloadType.DEPLOY_DATABASE);
+    if (actionBody.inputs) {
+      const inputs =
+        actionBody.inputs[0] instanceof ActionInput
+          ? (actionBody.inputs as ActionInput[])
+          : new ActionInput().putFromObjects(actionBody.inputs as Entries[]);
+
+      msg = msg.concat(inputs);
     }
 
-    /**
-    * Returns an instance of Drop Database Builder for this client.
-    *
-    * @returns A Drop Database Builder instance. Drop Database Builder is used to build drop database transactions to be broadcasted to the Kwil network.
-    */
-
-     public dropDbBuilder(): NonNil<DBBuilder<PayloadType.DROP_DATABASE>> {
-        return DBBuilderImpl.of<PayloadType.DROP_DATABASE>(this, PayloadType.DROP_DATABASE);
-     }
-
-    /**
-     * Broadcasts a transaction on the network.
-     *
-     * @param tx - The transaction to broadcast. The transaction can be built using the ActionBuilder or DBBuilder.
-     * @returns A promise that resolves to the receipt of the transaction. The transaction receipt includes the transaction hash, fee, and body.
-     */
-
-    public async broadcast(tx: BaseTransaction<BytesEncodingStatus.BASE64_ENCODED>): Promise<GenericResponse<TxReceipt>> {
-        return await this.client.broadcast(tx);
+    if (kwilSigner) {
+      msg = msg.signer(kwilSigner.signer, kwilSigner.signatureType).publicKey(kwilSigner.publicKey);
     }
 
-    /**
-     * Executes a transaction on a Kwil network. These are mutative actions that must be mined on the Kwil network's blockchain.
-     * 
-     * @param actionBody - The body of the action to send. This should use the `ActionBody` interface.
-     * @param kwilSigner - The signer for the action transactions.
-     * @returns A promise that resolves to the receipt of the transaction.
-    */
-    public async execute(actionBody: ActionBody, kwilSigner: KwilSigner): Promise<GenericResponse<TxReceipt>> {
-        let tx = ActionBuilderImpl.of(this)
-            .dbid(actionBody.dbid)
-            .name(actionBody.action)
-            .description(actionBody.description || '')
-            .publicKey(kwilSigner.publicKey)
-            .signer(kwilSigner.signer, kwilSigner.signatureType);
+    const message = await msg.buildMsg();
 
-        if(actionBody.inputs) {
-            const inputs = resolveActionInputs(actionBody.inputs);
+    return await this.client.call(message);
+  }
 
-            tx = tx.concat(inputs);
-        }
+  /**
+   * Lists all databases owned by a particular owner.
+   *
+   * @param owner - The owner's public key (Ethereum or NEAR Protocol). Ethereum keys can be passed as a hex string (0x123...) or as bytes (Uint8Array). NEAR protocol public keys can be passed as the base58 encoded public key (with "ed25519:" prefix), a hex string, or bytes (Uint8Array).
+   * @returns A promise that resolves to a list of database names.
+   */
 
-        const transaction = await tx.buildTx();
+  public async listDatabases(owner: string | Uint8Array): Promise<GenericResponse<string[]>> {
+    if (typeof owner === 'string') {
+      if (isNearPubKey(owner)) {
+        owner = nearB58ToHex(owner);
+      }
 
-        return await this.client.broadcast(transaction);
+      owner = owner.toLowerCase();
+      owner = hexToBytes(owner);
     }
 
-    /**
-     * Deploys a database to the Kwil network.
-     * 
-     * @param deployBody - The body of the database to deploy. This should use the `DeployBody` interface.
-     * @param kwilSigner - The signer for the database deployment.
-     * @returns A promise that resolves to the receipt of the transaction.
-     */
-    public async deploy(deployBody: DeployBody, kwilSigner: KwilSigner): Promise<GenericResponse<TxReceipt>> {
-        const tx = await DBBuilderImpl.of<PayloadType.DEPLOY_DATABASE>(this, PayloadType.DEPLOY_DATABASE)
-            .description(deployBody.description || '')
-            .payload(deployBody.schema)
-            .publicKey(kwilSigner.publicKey)
-            .signer(kwilSigner.signer, kwilSigner.signatureType)
-            .buildTx();
+    return await this.client.listDatabases(owner);
+  }
 
-        return await this.client.broadcast(tx);
+  /**
+   * Performs a SELECT query on a database. The query must be a read-only query.
+   *
+   * @param dbid - The unique identifier of the database. The DBID can be generated using the kwil.getDBID method.
+   * @param query - The SELECT query to execute.
+   * @returns A promise that resolves to a list of objects resulting from the query.
+   */
+
+  public async selectQuery(dbid: string, query: string): Promise<GenericResponse<Object[]>> {
+    const q: SelectQuery = {
+      dbid: dbid,
+      query: query,
+    };
+
+    let res = await this.client.selectQuery(q);
+    const uint8 = new Uint8Array(base64ToBytes(res.data as string));
+    const decoder = new TextDecoder('utf-8');
+    const jsonString = decoder.decode(uint8);
+    return {
+      status: res.status,
+      data: JSON.parse(jsonString),
+    } as GenericResponse<Map<string, any>[]>;
+  }
+
+  /**
+   * Retrieves information about a transaction given its hash.
+   *
+   * @param hash - The `tx_hash` of the transaction.
+   * @returns A promise that resolves to the transaction info receipt.
+   */
+  public async txInfo(hash: string): Promise<GenericResponse<TxInfoReceipt>> {
+    return await this.client.txInfo(hash);
+  }
+
+  /**
+   * Retrieves the chain id, block height, and latest block hash of the configured network.
+   * 
+   * Will log a warning if the returned chain id does not match the configured chain id.
+   * 
+   * @returns {ChainInfo} - A promise that resolves to the chain info.
+   */
+  public async chainInfo(): Promise<GenericResponse<ChainInfo>> {
+    const info = await this.client.chainInfo();
+
+    if(info.data?.chain_id !== this.chainId) {
+        console.warn(`WARNING: Chain ID mismatch. Expected ${this.chainId}, got ${info.data?.chain_id}`);
     }
 
-    /**
-     * Drops a database from the Kwil network.
-     * 
-     * @param dropBody - The body of the database to drop. This should use the `DropBody` interface.
-     * @param kwilSigner - The signer for the database drop.
-     * @returns A promise that resolves to the receipt of the transaction.
-     */
-    public async drop(dropBody: DropBody, kwilSigner: KwilSigner): Promise<GenericResponse<TxReceipt>> {
-        const tx = await DBBuilderImpl.of<PayloadType.DROP_DATABASE>(this, PayloadType.DROP_DATABASE)
-            .description(dropBody.description || '')
-            .payload({ dbid: dropBody.dbid })
-            .publicKey(kwilSigner.publicKey)
-            .signer(kwilSigner.signer, kwilSigner.signatureType)
-            .buildTx();
+    return info;
+  }
 
-        return await this.client.broadcast(tx);
-    }
-
-    /** 
-     * Calls a Kwil node. This can be used to execute read-only ('view') actions on Kwil.
-     * 
-     * @param actionBody - The body of the action to send. This should use the `ActionBody` interface.
-     * @param kwilSigner (optional) - The signer for the action call, if required. Signers are only required for actions with a `must_sign` attribute. You can check the attributes on an action by calling `kwil.getSchema(dbid)`.
-     * @returns A promise that resolves to the receipt of the message.
-    */
-        public async call(actionBody: ActionBody, kwilSigner?: KwilSigner): Promise<GenericResponse<MsgReceipt>>;
-
-    /**
-     * Calls a Kwil node. This can be used to execute read-only ('view') actions on Kwil.
-     * 
-     * @param actionBody - The message to send. The message can be built using the ActionBuilder class.
-     * @returns A promise that resolves to the receipt of the message.
-     */
-    public async call(actionBody: Message): Promise<GenericResponse<MsgReceipt>>;
-
-    public async call(actionBody: Message | ActionBody, kwilSigner?: KwilSigner): Promise<GenericResponse<MsgReceipt>> {
-        if(actionBody instanceof BaseMessage) {
-            return await this.client.call(actionBody);
-        }
-
-        let msg = this.actionBuilder()
-            .dbid(actionBody.dbid)
-            .name(actionBody.action)
-            .description(actionBody.description || '')
-
-            if(actionBody.inputs) {
-                const inputs = actionBody.inputs[0] instanceof ActionInput ? actionBody.inputs as ActionInput[] : new ActionInput().putFromObjects(actionBody.inputs as Entries[]);
-
-                msg = msg.concat(inputs);
-            }
-
-            if(kwilSigner) {
-                msg = msg
-                    .signer(kwilSigner.signer, kwilSigner.signatureType)
-                    .publicKey(kwilSigner.publicKey)
-            }
-            
-        const message = await msg.buildMsg();
-        
-        return await this.client.call(message);
-    }
-
-    /**
-     * Lists all databases owned by a particular owner.
-     *
-     * @param owner - The owner's public key (Ethereum or NEAR Protocol). Ethereum keys can be passed as a hex string (0x123...) or as bytes (Uint8Array). NEAR protocol public keys can be passed as the base58 encoded public key (with "ed25519:" prefix), a hex string, or bytes (Uint8Array).
-     * @returns A promise that resolves to a list of database names.
-     */
-
-    public async listDatabases(owner: string | Uint8Array): Promise<GenericResponse<string[]>> {
-        if(typeof owner === 'string') {
-            if(isNearPubKey(owner)) {
-                owner = nearB58ToHex(owner);
-            }
-
-            owner = owner.toLowerCase();
-            owner = hexToBytes(owner);
-        }
-
-        return await this.client.listDatabases(owner);
-    }
-
-    /**
-     * Pings the server and gets a response.
-     *
-     * @returns A promise that resolves to a string indicating the server's response.
-     */
-
-    public async ping(): Promise<GenericResponse<string>> {
-        return await this.client.ping();
-    }
-
-    /**
-     * Performs a SELECT query on a database. The query must be a read-only query.
-     *
-     * @param dbid - The unique identifier of the database. The DBID can be generated using the kwil.getDBID method.
-     * @param query - The SELECT query to execute.
-     * @returns A promise that resolves to a list of objects resulting from the query.
-     */
-
-    public async selectQuery(dbid: string, query: string): Promise<GenericResponse<Object[]>> {
-        const q: SelectQuery = {
-            dbid: dbid,
-            query: query,
-        }
-
-        let res = await this.client.selectQuery(q);
-        const uint8 = new Uint8Array(base64ToBytes(res.data as string));
-        const decoder = new TextDecoder('utf-8');
-        const jsonString = decoder.decode(uint8);
-        return {
-            status: res.status,
-            data: JSON.parse(jsonString),
-        } as GenericResponse<Map<string, any>[]>;
-    }
-
-    /** 
-     * Retrieves information about a transaction given its hash.
-     * 
-     * @param hash - The `tx_hash` of the transaction.
-     * @returns A promise that resolves to the transaction info receipt.
-    */
-    public async txInfo(hash: string): Promise<GenericResponse<TxInfoReceipt>> {
-        return await this.client.txInfo(hash);
-    }
+  /**
+   * Pings the server and gets a response.
+   *
+   * @returns A promise that resolves to a string indicating the server's response.
+   */
+  public async ping(): Promise<GenericResponse<string>> {
+    return await this.client.ping();
+  }
 }

--- a/src/client/node/nodeKwil.ts
+++ b/src/client/node/nodeKwil.ts
@@ -1,8 +1,8 @@
-import { Config } from "../../api_client/config";
-import { Kwil } from "../kwil";
+import { Config } from '../../api_client/config';
+import { Kwil } from '../kwil';
 
 export class NodeKwil extends Kwil {
-    constructor(opts: Config) {
-        super(opts);
-    }
+  constructor(opts: Config) {
+    super(opts);
+  }
 }

--- a/src/client/web/webKwil.ts
+++ b/src/client/web/webKwil.ts
@@ -1,8 +1,8 @@
-import { Config } from "../../api_client/config";
-import { Kwil } from "../kwil";
+import { Config } from '../../api_client/config';
+import { Kwil } from '../kwil';
 
 export class WebKwil extends Kwil {
-    constructor(opts: Config) {
-        super(opts);
-    }
+  constructor(opts: Config) {
+    super(opts);
+  }
 }

--- a/src/core/account.ts
+++ b/src/core/account.ts
@@ -1,5 +1,0 @@
-export interface Account {
-    public_key: Uint8Array | string;
-    balance: string;
-    nonce: string;
-}

--- a/src/core/builders.ts
+++ b/src/core/builders.ts
@@ -1,267 +1,291 @@
-import { HexString, Nillable, NonNil, Promisy } from "../utils/types";
-import { BaseTransaction, Transaction } from "./tx";
-import {ethers, Signer as _Signer, JsonRpcSigner } from "ethers";
-import {ActionInput} from "./action";
-import {Wallet as Walletv5, Signer as Signerv5} from "ethers5";
-import { DeployOrDrop, PayloadType } from "./enums";
-import { Message } from "./message";
-import { AnySignatureType } from "./signature";
-import { DbPayloadType } from "./payload";
+import { HexString, Nillable, NonNil, Promisy } from '../utils/types';
+import { BaseTransaction, Transaction } from './tx';
+import { ethers, Signer as _Signer, JsonRpcSigner } from 'ethers';
+import { ActionInput } from './action';
+import { Wallet as Walletv5, Signer as Signerv5 } from 'ethers5';
+import { DeployOrDrop, PayloadType } from './enums';
+import { Message } from './message';
+import { AnySignatureType } from './signature';
+import { DbPayloadType } from './payload';
 
 export type EthSigner = NonNil<_Signer | JsonRpcSigner | ethers.Wallet | Walletv5 | Signerv5>;
 
-export type CustomSigner = NonNil<(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>>
-export type SignerSupplier = Promisy<EthSigner | CustomSigner>
+export type CustomSigner = NonNil<(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>>;
+export type SignerSupplier = Promisy<EthSigner | CustomSigner>;
 
 /**
  * `PayloadBuilder` is the interface for building transactions and messages that are sent over GRPC to a Kwil network.
  */
 export interface PayloadBuilder {
-    /**
-     * Specify the payload type to be built.
-     * 
-     * @param {PayloadType} payloadType - The payload type to be built. See {@link PayloadType} for more information.
-     * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
-     * @throws {Error} - If the payload type is null or undefined.
-     */
-    payloadType(payloadType: NonNil<PayloadType>): NonNil<PayloadBuilder>;
+  /**
+   * Specify the payload type to be built.
+   *
+   * @param {PayloadType} payloadType - The payload type to be built. See {@link PayloadType} for more information.
+   * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
+   * @throws {Error} - If the payload type is null or undefined.
+   */
+  payloadType(payloadType: NonNil<PayloadType>): NonNil<PayloadBuilder>;
 
-    /**
-     * Specify the signer and the signature type.
-     * 
-     * @param {SignerSupplier} signer - The signer to be used to sign the transaction.
-     * @param {AnySignatureType} sigType - The signature type to be used to sign the transaction. See {@link AnySignatureType} for more information.
-     * @returns The current `PayloadBuilder` instance for chaining.
-     * @throws {Error} - If the signer is null or undefined.
-     * @throws {Error} - If the signature type is null or undefined.
-     */
-    signer(signer: SignerSupplier, sigType: AnySignatureType): NonNil<PayloadBuilder>;
+  /**
+   * Specify the signer and the signature type.
+   *
+   * @param {SignerSupplier} signer - The signer to be used to sign the transaction.
+   * @param {AnySignatureType} sigType - The signature type to be used to sign the transaction. See {@link AnySignatureType} for more information.
+   * @returns The current `PayloadBuilder` instance for chaining.
+   * @throws {Error} - If the signer is null or undefined.
+   * @throws {Error} - If the signature type is null or undefined.
+   */
+  signer(signer: SignerSupplier, sigType: AnySignatureType): NonNil<PayloadBuilder>;
 
-    /**
-     * Specify the public key for the payload signer.
-     * 
-     * @param {HexString | Uint8Array} publicKey - The public key to be used to sign the transaction. This can be a hex string or a Uint8Array.
-     * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
-     * @throws {Error} - If the public key is null or undefined.
-     */
-    publicKey(publicKey: HexString | Uint8Array): NonNil<PayloadBuilder>;
+  /**
+   * Specify the public key for the payload signer.
+   *
+   * @param {HexString | Uint8Array} publicKey - The public key to be used to sign the transaction. This can be a hex string or a Uint8Array.
+   * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
+   * @throws {Error} - If the public key is null or undefined.
+   */
+  publicKey(publicKey: HexString | Uint8Array): NonNil<PayloadBuilder>;
 
-    /**
-     * Set the description to be included in the payload signature.
-     * 
-     * @param {string | null} description - The description to be included in the payload signature.
-     * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
-     */
-    description(description: Nillable<string>): NonNil<PayloadBuilder>;
+  /**
+   * Set the description to be included in the payload signature.
+   *
+   * @param {string | null} description - The description to be included in the payload signature.
+   * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
+   */
+  description(description: Nillable<string>): NonNil<PayloadBuilder>;
 
-    /**
-     * Sets the content for the body of the payload object.
-     * 
-     * @param {() => NonNil<AllPayloads> | NonNil<AllPayloads>} payload - The payload to be built. This can be a function that returns an object or an object.
-     * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
-     * @throws {Error} - If the payload is null or undefined.
-     */
-    payload(payload: (() => NonNil<object>) | NonNil<object>): NonNil<PayloadBuilder>;
+  /**
+   * Sets the content for the body of the payload object.
+   *
+   * @param {() => NonNil<AllPayloads> | NonNil<AllPayloads>} payload - The payload to be built. This can be a function that returns an object or an object.
+   * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
+   * @throws {Error} - If the payload is null or undefined.
+   */
+  payload(payload: (() => NonNil<object>) | NonNil<object>): NonNil<PayloadBuilder>;
 
-    /**
-     * Builds the payload for the `kwil.broadcast()` method (i.e. the broadcast GRPC endpoint - see {@link https://github.com/kwilteam/proto/blob/main/kwil/tx/v1/broadcast.proto})
-     * 
-     * @returns {BaseTransaction} - A promise that resolves to the signed transaction.
-     * @throws {Error} - If the required fields in the builder are null or undefined.
-     */
-    buildTx(): Promise<Transaction>;
+  /**
+   * Specifies the chain ID for the network being used.
+   *
+   * @param {string} chainId - The chain ID for the network being used.
+   * @returns {PayloadBuilder} The current `PayloadBuilder` instance for chaining.
+   */
+  chainId(chainId: string): NonNil<PayloadBuilder>;
 
-    /**
-     * Build the payload structure for message to the `kwil.call()` method (i.e. the call GRPC endpoint - see {@link https://github.com/kwilteam/proto/blob/main/kwil/tx/v1/call.proto})
-     * 
-     * @returns {Message} - A promise that resolves to the built message, with signature if provided.
-     * @throws {Error} - If the required fields in the builder are null or undefined.
-     */
-    buildMsg(): Promise<Message>;
+  /**
+   * Builds the payload for the `kwil.broadcast()` method (i.e. the broadcast GRPC endpoint - see {@link https://github.com/kwilteam/proto/blob/main/kwil/tx/v1/broadcast.proto})
+   *
+   * @returns {BaseTransaction} - A promise that resolves to the signed transaction.
+   * @throws {Error} - If the required fields in the builder are null or undefined.
+   */
+  buildTx(): Promise<Transaction>;
+
+  /**
+   * Build the payload structure for message to the `kwil.call()` method (i.e. the call GRPC endpoint - see {@link https://github.com/kwilteam/proto/blob/main/kwil/tx/v1/call.proto})
+   *
+   * @returns {Message} - A promise that resolves to the built message, with signature if provided.
+   * @throws {Error} - If the required fields in the builder are null or undefined.
+   */
+  buildMsg(): Promise<Message>;
 }
 
 /**
  * `DBBuilder` is the interface for building database deployment and database drop transactions.
  */
 export interface DBBuilder<T extends DeployOrDrop> {
-    /**
-     * Specify the signer for the action operation.
-     * 
-     * @param {EthSigner} signer - The signer for the database operation. This must be a signer from Ethers v5 or Ethers v6.
-     * @returns {DBBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the action is being built.
-     * @throws Will throw an error if the signer is null or undefined.
-     * @throws Will throw an error if it cannot infer the signature type from the signer.
-     */
-    signer(signer: EthSigner): NonNil<DBBuilder<T>>;
+  /**
+   * Specify the signer for the action operation.
+   *
+   * @param {EthSigner} signer - The signer for the database operation. This must be a signer from Ethers v5 or Ethers v6.
+   * @returns {DBBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the action is being built.
+   * @throws Will throw an error if the signer is null or undefined.
+   * @throws Will throw an error if it cannot infer the signature type from the signer.
+   */
+  signer(signer: EthSigner): NonNil<DBBuilder<T>>;
 
-    /**
-     * Specify the signer for the action operation.
-     * 
-     * @param {CustomSigner} signer - The signer for the database operation. This must be a custom signer function of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
-     * @param {AnySignatureType} signatureType - The signature type for the database operation. This can be a `SignatureType` enum value or a string for a network-specific signature type, if implemented at the network level.
-     * @returns {DBBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the action is being built.
-     * @throws Will throw an error if the signer is null or undefined.
-     * @throws Will throw an error if the signature type is null or undefined.
-     */
-    signer(signer: CustomSigner, signatureType: AnySignatureType): NonNil<DBBuilder<T>>;
+  /**
+   * Specify the signer for the action operation.
+   *
+   * @param {CustomSigner} signer - The signer for the database operation. This must be a custom signer function of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
+   * @param {AnySignatureType} signatureType - The signature type for the database operation. This can be a `SignatureType` enum value or a string for a network-specific signature type, if implemented at the network level.
+   * @returns {DBBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the action is being built.
+   * @throws Will throw an error if the signer is null or undefined.
+   * @throws Will throw an error if the signature type is null or undefined.
+   */
+  signer(signer: CustomSigner, signatureType: AnySignatureType): NonNil<DBBuilder<T>>;
 
-    /**
-     * Specifies the signer for the database transaction.
-     * 
-     * @param {SignerSupplier} signer - The signer for the database transaction. This can be a `Signer` from Ethers v5 or Ethers v6 or a custom signer function. Custom signers must be of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
-     * @param {AnySignatureType} signatureType - The signature type for the database transaction. This is only required if the signer is a custom signer function. 
-     * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-     * @throws Will throw an error if the signer is null or undefined.
-     * @throws Will throw an error if the signature type is null or undefined.
-     * @throws Will throw an error if it cannot infer the signature type from the signer.
-     */
-    signer(signer: SignerSupplier, signatureType?: AnySignatureType): NonNil<DBBuilder<T>>;
+  /**
+   * Specifies the signer for the database transaction.
+   *
+   * @param {SignerSupplier} signer - The signer for the database transaction. This can be a `Signer` from Ethers v5 or Ethers v6 or a custom signer function. Custom signers must be of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
+   * @param {AnySignatureType} signatureType - The signature type for the database transaction. This is only required if the signer is a custom signer function.
+   * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
+   * @throws Will throw an error if the signer is null or undefined.
+   * @throws Will throw an error if the signature type is null or undefined.
+   * @throws Will throw an error if it cannot infer the signature type from the signer.
+   */
+  signer(signer: SignerSupplier, signatureType?: AnySignatureType): NonNil<DBBuilder<T>>;
 
-     /**
-     * The payload for the database deployment or database drop.
-     * 
-     * @param {DbPayloadType<T>} payload - The payload for the database deployment or database drop. This should be a callback function that resolves to either a `CompiledKuneiform` or `DropDbPayload` object, or just objects that match either of those interfaces.
-     * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-     * @throws Will throw an error if the payload is null or undefined.
-     */
-    payload(payload: DbPayloadType<T>): NonNil<DBBuilder<T>>;
+  /**
+   * The payload for the database deployment or database drop.
+   *
+   * @param {DbPayloadType<T>} payload - The payload for the database deployment or database drop. This should be a callback function that resolves to either a `CompiledKuneiform` or `DropDbPayload` object, or just objects that match either of those interfaces.
+   * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
+   * @throws Will throw an error if the payload is null or undefined.
+   */
+  payload(payload: DbPayloadType<T>): NonNil<DBBuilder<T>>;
 
-    /**
-     * Specifies the public key for the database deployment / drop.
-     * 
-     * @param {HexString | Uint8Array} publicKey - The public key for the database deployment / drop. 
-     * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-     * @throws Will throw an error if the public key is null or undefined.
-     */
-    publicKey(publicKey: HexString | Uint8Array): NonNil<DBBuilder<T>>;
+  /**
+   * Specifies the public key for the database deployment / drop.
+   *
+   * @param {HexString | Uint8Array} publicKey - The public key for the database deployment / drop.
+   * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
+   * @throws Will throw an error if the public key is null or undefined.
+   */
+  publicKey(publicKey: HexString | Uint8Array): NonNil<DBBuilder<T>>;
 
-    /**
-     * Specifies the descriptions to be included in the message that is signed.
-     * 
-     * @param {string} description - The description to be included in the message that is signed. 
-     * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-     * @throws Will throw an error if the description is null or undefined.
-     */
-    description(description: string): NonNil<DBBuilder<T>>;
+  /**
+   * Specifies the chain ID for the network being used.
+   *
+   * @param {string} chainId - The chain ID for the network being used.
+   * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
+   */
+  chainId(chainId: string): NonNil<DBBuilder<T>>;
 
-    /**
-     * Builds a Transaction. This will call the kwil network to retrieve the nonce for the signer.
-     * 
-     * @returns {Promise<Transaction>} - A promise that resolves to a `Transaction` object. The `Transaction` object can be broadcasted to the Kwil network using `kwil.broadcast(tx)`.
-     * @throws Will throw an error if there are any errors in the payload.
-     * @throws Will throw an error if there is an issue with the account retrieval.
-     */
-    buildTx(): Promise<Transaction>;
+  /**
+   * Specifies the descriptions to be included in the message that is signed.
+   *
+   * @param {string} description - The description to be included in the message that is signed.
+   * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
+   * @throws Will throw an error if the description is null or undefined.
+   */
+  description(description: string): NonNil<DBBuilder<T>>;
+
+  /**
+   * Builds a Transaction. This will call the kwil network to retrieve the nonce for the signer.
+   *
+   * @returns {Promise<Transaction>} - A promise that resolves to a `Transaction` object. The `Transaction` object can be broadcasted to the Kwil network using `kwil.broadcast(tx)`.
+   * @throws Will throw an error if there are any errors in the payload.
+   * @throws Will throw an error if there is an issue with the account retrieval.
+   */
+  buildTx(): Promise<Transaction>;
 }
 
 /**
  * `ActionBuilder` is the interface for building `update` action transactions and `view` actions messages.
  */
 export interface ActionBuilder {
-    /**
-     * Specifies the name of the action to be executed.
-     * 
-     * @param {string} actionName - The name of the action to be executed.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the action name is null or undefined.
-     */
-    name(actionName: string): NonNil<ActionBuilder>;
+  /**
+   * Specifies the name of the action to be executed.
+   *
+   * @param {string} actionName - The name of the action to be executed.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the action name is null or undefined.
+   */
+  name(actionName: string): NonNil<ActionBuilder>;
 
-    /**
-     * Specifies the database identifier (DBID) of the database that contains the action to be executed.
-     * 
-     * @param {string} dbid - The database identifier.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the dbid is null or undefined.
-     */
-    dbid(dbid: string): NonNil<ActionBuilder>;
+  /**
+   * Specifies the database identifier (DBID) of the database that contains the action to be executed.
+   *
+   * @param {string} dbid - The database identifier.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the dbid is null or undefined.
+   */
+  dbid(dbid: string): NonNil<ActionBuilder>;
 
-   /**
-     * Adds actionInputs to the list of inputs to be executed in the action.
-     * 
-     * @param {ActionInput | ActionInput[]} actions - The actions to add. This should be from the `ActionInput` class.
-     * @returns The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the action is null or undefined.
-     */
-    concat(action: ActionInput | ActionInput[]): NonNil<ActionBuilder>;
+  /**
+   * Adds actionInputs to the list of inputs to be executed in the action.
+   *
+   * @param {ActionInput | ActionInput[]} actions - The actions to add. This should be from the `ActionInput` class.
+   * @returns The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the action is null or undefined.
+   */
+  concat(action: ActionInput | ActionInput[]): NonNil<ActionBuilder>;
 
-    /**
-     * Specify the signer for the action operation.
-     * 
-     * @param {EthSigner} signer - The signer for the database operation. This must be a signer from Ethers v5 or Ethers v6.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the action is being built.
-     * @throws Will throw an error if the signer is null or undefined.
-     * @throws Will throw an error if it cannot infer the signature type from the signer.
-     */
-    signer(signer: EthSigner): NonNil<ActionBuilder>;
+  /**
+   * Specify the signer for the action operation.
+   *
+   * @param {EthSigner} signer - The signer for the database operation. This must be a signer from Ethers v5 or Ethers v6.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the action is being built.
+   * @throws Will throw an error if the signer is null or undefined.
+   * @throws Will throw an error if it cannot infer the signature type from the signer.
+   */
+  signer(signer: EthSigner): NonNil<ActionBuilder>;
 
-    /**
-     * Specify the signer for the action operation.
-     * 
-     * @param {CustomSigner} signer - The signer for the database operation. This must be a custom signer function of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
-     * @param {AnySignatureType} signatureType - The signature type for the database operation. This can be a `SignatureType` enum value or a string for a network-specific signature type, if implemented at the network level.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the action is being built.
-     * @throws Will throw an error if the signer is null or undefined.
-     * @throws Will throw an error if the signature type is null or undefined.
-     */
-    signer(signer: CustomSigner, signatureType: AnySignatureType): NonNil<ActionBuilder>;
+  /**
+   * Specify the signer for the action operation.
+   *
+   * @param {CustomSigner} signer - The signer for the database operation. This must be a custom signer function of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
+   * @param {AnySignatureType} signatureType - The signature type for the database operation. This can be a `SignatureType` enum value or a string for a network-specific signature type, if implemented at the network level.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the action is being built.
+   * @throws Will throw an error if the signer is null or undefined.
+   * @throws Will throw an error if the signature type is null or undefined.
+   */
+  signer(signer: CustomSigner, signatureType: AnySignatureType): NonNil<ActionBuilder>;
 
-    /** 
-     * Specifies the signer for the action operation.
-     * 
-     * @param {SignerSupplier} signer - The signer for the database operation. This can be a signer from Ethers v5 or Ethers v6 or a custom signer function of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
-     * @param {AnySignatureType} signatureType - The signature type for the database operation. This can be a `SignatureType` enum value or a string for a network-specific signature type. Ethers v5 and Ethers v6 signers will have the signature type inferred from the signer.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the action is being built.
-     * @throws Will throw an error if the signer is null or undefined.
-     * @throws Will throw an error if the signature type is null or undefined.
-     * @throws Will throw an error if it cannot infer the signature type from the signer.
-    */
+  /**
+   * Specifies the signer for the action operation.
+   *
+   * @param {SignerSupplier} signer - The signer for the database operation. This can be a signer from Ethers v5 or Ethers v6 or a custom signer function of the form `(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>`.
+   * @param {AnySignatureType} signatureType - The signature type for the database operation. This can be a `SignatureType` enum value or a string for a network-specific signature type. Ethers v5 and Ethers v6 signers will have the signature type inferred from the signer.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the action is being built.
+   * @throws Will throw an error if the signer is null or undefined.
+   * @throws Will throw an error if the signature type is null or undefined.
+   * @throws Will throw an error if it cannot infer the signature type from the signer.
+   */
 
-    signer(signer: SignerSupplier, signatureType?: AnySignatureType): NonNil<ActionBuilder>;
+  signer(signer: SignerSupplier, signatureType?: AnySignatureType): NonNil<ActionBuilder>;
 
-    /**
-     * Specifies the public key of the wallet signing for the database operation.
-     * 
-     * @param {HexString | Uint8Array} publicKey - The public key of the wallet signing for the database operation.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the public key is null or undefined.
-     */
-    publicKey(publicKey: HexString | Uint8Array): NonNil<ActionBuilder>;
+  /**
+   * Specifies the public key of the wallet signing for the database operation.
+   *
+   * @param {HexString | Uint8Array} publicKey - The public key of the wallet signing for the database operation.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the public key is null or undefined.
+   */
+  publicKey(publicKey: HexString | Uint8Array): NonNil<ActionBuilder>;
 
-    /**
-     * Specifies the description to be included in the message that is signed.
-     * 
-     * @param {string} description - The description to be included in the message that is signed.
-     * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
-     * @throws Will throw an error if the value is specified while the action is being built.
-     * @throws Will throw an error if the description is null or undefined.
-     */
-    description(description: string): NonNil<ActionBuilder>;
+  /**
+   * Specifies the description to be included in the message that is signed.
+   *
+   * @param {string} description - The description to be included in the message that is signed.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   * @throws Will throw an error if the value is specified while the action is being built.
+   * @throws Will throw an error if the description is null or undefined.
+   */
+  description(description: string): NonNil<ActionBuilder>;
 
-    /**
-     * Builds a transaction. This will call the kwil network to retrieve the schema and the signer's account.
-     * 
-     * @returns {Promise<BaseTransaction>} - A promise that resolves to a Transaction object. This transaction can be broadcasted to the Kwil network with the `kwil.broadcast()` api.
-     * @throws Will throw an error if the action is being built or if there's an issue with the schema or account retrieval.
-     * @throws Will throw an error if the action is not a update action.
-     */
-    buildTx(): Promise<Transaction>;
+  /**
+   * Specifies the chain ID for the network being used.
+   *
+   * @param {string} chainId - The chain ID for the network being used.
+   * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
+   */
+  chainId(chainId: string): NonNil<ActionBuilder>;
 
-    /**
-     * Builds the message structure for view actions. This can be provided to the `kwil.call()` api.
-     * 
-     * @returns {Promise<Message>} - A message object that can be sent to the Kwil network.
-     * @throws Will throw an error if the action is being built or if there's an issue with the schema or account retrieval.
-     * @throws Will throw an error if the action is not a view action.
-     */
-    buildMsg(): Promise<Message>;
+  /**
+   * Builds a transaction. This will call the kwil network to retrieve the schema and the signer's account.
+   *
+   * @returns {Promise<BaseTransaction>} - A promise that resolves to a Transaction object. This transaction can be broadcasted to the Kwil network with the `kwil.broadcast()` api.
+   * @throws Will throw an error if the action is being built or if there's an issue with the schema or account retrieval.
+   * @throws Will throw an error if the action is not a update action.
+   */
+  buildTx(): Promise<Transaction>;
+
+  /**
+   * Builds the message structure for view actions. This can be provided to the `kwil.call()` api.
+   *
+   * @returns {Promise<Message>} - A message object that can be sent to the Kwil network.
+   * @throws Will throw an error if the action is being built or if there's an issue with the schema or account retrieval.
+   * @throws Will throw an error if the action is not a view action.
+   */
+  buildMsg(): Promise<Message>;
 }

--- a/src/core/network.ts
+++ b/src/core/network.ts
@@ -1,0 +1,13 @@
+// network.ts contains interfaces for network-related data structures.
+
+export interface Account {
+    public_key: Uint8Array | string;
+    balance: string;
+    nonce: string;
+}
+
+export interface ChainInfo {
+    chain_id: string;
+    height: string;
+    hash: string;
+}

--- a/src/core/resreq.ts
+++ b/src/core/resreq.ts
@@ -1,65 +1,65 @@
-import {Database} from "./database";
-import {Account} from "./account";
-import {BaseTransaction, TxnData } from "./tx";
-import { TxResult } from "./txQuery";
-import { BytesEncodingStatus } from "./enums";
+import { Database } from './database';
+import { Account, ChainInfo } from './network';
+import { BaseTransaction, TxReceipt, TxnData } from './tx';
+import { TxResult } from './txQuery';
+import { BytesEncodingStatus } from './enums';
 
 type SchemaRes = Database & {
-    owner: string;
-}
+  owner: string;
+};
 
 export interface GenericResponse<T> {
-    status: number;
-    data?: T;
+  status: number;
+  data?: T;
 }
 
 export interface GetSchemaResponse {
-    schema: SchemaRes;
+  schema: SchemaRes;
 }
 
 export interface GetAccountResponse {
-    account: Account;
+  account: Account;
 }
 
 export interface ListDatabasesResponse {
-    databases: string[];
+  databases: string[];
 }
 
 export interface EstimateCostReq {
-    tx: TxnData<BytesEncodingStatus.BASE64_ENCODED>;
+  tx: TxnData<BytesEncodingStatus.BASE64_ENCODED>;
 }
 
 export interface EstimateCostRes {
-    price: string;
+  price: string;
 }
 
 export interface BroadcastReq {
-    tx: TxnData<BytesEncodingStatus.BASE64_ENCODED>;
+  tx: TxnData<BytesEncodingStatus.BASE64_ENCODED>;
 }
 
-export interface BroadcastRes {
-    tx_hash: string;
-}
+export interface BroadcastRes extends TxReceipt {}
 
 export interface CallRes {
-    result: string;
+  result: string;
 }
 
 export interface PongRes {
-    message: string;
+  message: string;
 }
 
 export interface SelectRes {
-    result: string
+  result: string;
 }
 
 export interface TxQueryReq {
-    tx_hash: string;
+  tx_hash: string;
 }
 
 export interface TxQueryRes {
-    hash: string;
-    height: number;
-    tx: BaseTransaction<BytesEncodingStatus.BASE64_ENCODED>;
-    tx_result: TxResult;
+  hash: string;
+  height: number;
+  tx: BaseTransaction<BytesEncodingStatus.BASE64_ENCODED>;
+  tx_result: TxResult;
 }
+
+export interface ChainInfoRes extends ChainInfo {}

--- a/src/core/tx.ts
+++ b/src/core/tx.ts
@@ -27,7 +27,7 @@ interface TxBody<T extends PayloadBytesTypes> {
     // once bytes are set to base64, it means the tx is ready to be sent over GRPC, which means BigInt needs to be converted to string
     fee: Nillable<T extends BytesEncodingStatus.BASE64_ENCODED ? string : BigInt>;
     nonce: number | null;
-    salt: Nillable<T extends BytesEncodingStatus.BASE64_ENCODED ? Base64String : Uint8Array>;
+    chain_id: string;
 }
 
 /**
@@ -59,7 +59,7 @@ export class BaseTransaction<T extends PayloadBytesTypes> implements TxnData<T> 
                 payload_type: PayloadType.INVALID_PAYLOAD_TYPE,
                 fee: null,
                 nonce: null,
-                salt: null,     
+                chain_id: ''
             },
             sender: null,
             serialization: SerializationType.SIGNED_MSG_CONCAT
@@ -113,7 +113,7 @@ export namespace Txn {
                 payload_type: PayloadType.INVALID_PAYLOAD_TYPE,
                 fee: null,
                 nonce: null,
-                salt: null,
+                chain_id: '' 
             },
             sender: null,
             serialization: SerializationType.SIGNED_MSG_CONCAT

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,69 +1,78 @@
-import {NodeKwil} from './client/node/nodeKwil'
-import {WebKwil} from './client/web/webKwil'
-import { generateDBID } from './utils/dbid'
-import { TxReceipt as _TxReceipt } from './core/tx'
-import { ActionBuilder as _ActionBuilder, DBBuilder as _DBBuilder } from './core/builders'
-import { ActionInput as _ActionInput, ActionBody as _ActionBody } from './core/action'
-import { Transaction as _Transaction } from './core/tx'
-import { Database as _Database, Table as _Table, Column as _Column, 
-    Attribute as _Attribute, Index as _Index, ActionSchema as _ActionSchema, 
-    SelectQuery as _SelectQuery, ForeignKey as _ForeignKey, ForeignKeyAction as _ForeignKeyAction, 
-    Extension as _Extension, ExtensionConfig as _ExtensionConfig, DeployBody as _DeployBody,
-    DropBody as _DropBody
-} from './core/database'
-import { GenericResponse as _GenericResponse } from './core/resreq'
-import { TxResult as _TxResult, TxInfoReceipt as _TxInfoReceipt } from './core/txQuery'
-import { Account as _Account } from './core/account'
-import { MsgReceipt as _MsgReceipt, Message as _Message } from './core/message'
-import { recoverSecp256k1PubKey } from './utils/keys'
-import { KwilSigner } from './core/kwilSigner'
-import { DeployOrDrop, PayloadType as _PayloadType } from './core/enums'
+import { NodeKwil } from './client/node/nodeKwil';
+import { WebKwil } from './client/web/webKwil';
+import { generateDBID } from './utils/dbid';
+import { TxReceipt as _TxReceipt } from './core/tx';
+import { ActionBuilder as _ActionBuilder, DBBuilder as _DBBuilder } from './core/builders';
+import { ActionInput as _ActionInput, ActionBody as _ActionBody } from './core/action';
+import { Transaction as _Transaction } from './core/tx';
+import {
+  Database as _Database,
+  Table as _Table,
+  Column as _Column,
+  Attribute as _Attribute,
+  Index as _Index,
+  ActionSchema as _ActionSchema,
+  SelectQuery as _SelectQuery,
+  ForeignKey as _ForeignKey,
+  ForeignKeyAction as _ForeignKeyAction,
+  Extension as _Extension,
+  ExtensionConfig as _ExtensionConfig,
+  DeployBody as _DeployBody,
+  DropBody as _DropBody,
+} from './core/database';
+import { GenericResponse as _GenericResponse } from './core/resreq';
+import { TxResult as _TxResult, TxInfoReceipt as _TxInfoReceipt } from './core/txQuery';
+import { Account as _Account } from './core/network';
+import { MsgReceipt as _MsgReceipt, Message as _Message } from './core/message';
+import { recoverSecp256k1PubKey } from './utils/keys';
+import { KwilSigner } from './core/kwilSigner';
+import { DeployOrDrop, PayloadType as _PayloadType } from './core/enums';
 
 namespace Types {
-    export type TxReceipt = _TxReceipt
-    export type MsgReceipt = _MsgReceipt
-    export type ActionBuilder = _ActionBuilder
-    export type ActionInput = _ActionInput
-    export type DBBuilder<T extends DeployOrDrop> = _DBBuilder<T>
-    export type Transaction= _Transaction
-    export type Message = _Message
-    export type Database = _Database
-    export type Table = _Table
-    export type Column = _Column
-    export type Attribute = _Attribute
-    export type Index = _Index
-    export type ForeignKey = _ForeignKey
-    export type ForeignKeyAction = _ForeignKeyAction
-    export type ActionSchema = _ActionSchema
-    export type Extension = _Extension
-    export type ExtensionConfig = _ExtensionConfig
-    export type SelectQuery = _SelectQuery
-    export type GenericResponse<T> = _GenericResponse<T>
-    export type TxResult = _TxResult
-    export type TxInfoReceipt = _TxInfoReceipt
-    export type Account = _Account
-    export type PayloadType = _PayloadType
-    export type DeployBody = _DeployBody
-    export type DropBody = _DropBody
-    export type ActionBody = _ActionBody
+  export type TxReceipt = _TxReceipt;
+  export type MsgReceipt = _MsgReceipt;
+  export type ActionBuilder = _ActionBuilder;
+  export type ActionInput = _ActionInput;
+  export type DBBuilder<T extends DeployOrDrop> = _DBBuilder<T>;
+  export type Transaction = _Transaction;
+  export type Message = _Message;
+  export type Database = _Database;
+  export type Table = _Table;
+  export type Column = _Column;
+  export type Attribute = _Attribute;
+  export type Index = _Index;
+  export type ForeignKey = _ForeignKey;
+  export type ForeignKeyAction = _ForeignKeyAction;
+  export type ActionSchema = _ActionSchema;
+  export type Extension = _Extension;
+  export type ExtensionConfig = _ExtensionConfig;
+  export type SelectQuery = _SelectQuery;
+  export type GenericResponse<T> = _GenericResponse<T>;
+  export type TxResult = _TxResult;
+  export type TxInfoReceipt = _TxInfoReceipt;
+  export type Account = _Account;
+  export type PayloadType = _PayloadType;
+  export type DeployBody = _DeployBody;
+  export type DropBody = _DropBody;
+  export type ActionBody = _ActionBody;
 }
 
-const ActionInput = _ActionInput
+const ActionInput = _ActionInput;
 
 const Utils = {
-/**
- * `ActionInput` class is a utility class for creating action inputs.
- */
-    ActionInput,
-/**
- * Generates a unique database identifier (DBID) from the provided owner's Ethereum wallet address and a database name.
- */
-    generateDBID,
-/**
- * Recovers the public key from a signature and a message for Secp256k1 Public Keys (EVM Networks).
- * @param signer - The signer for the action. This must be a valid Ethereum signer from Ethers v5 or Ethers v6.
- */
-    recoverSecp256k1PubKey
-}
+  /**
+   * `ActionInput` class is a utility class for creating action inputs.
+   */
+  ActionInput,
+  /**
+   * Generates a unique database identifier (DBID) from the provided owner's Ethereum wallet address and a database name.
+   */
+  generateDBID,
+  /**
+   * Recovers the public key from a signature and a message for Secp256k1 Public Keys (EVM Networks).
+   * @param signer - The signer for the action. This must be a valid Ethereum signer from Ethers v5 or Ethers v6.
+   */
+  recoverSecp256k1PubKey,
+};
 
-export { NodeKwil, WebKwil, KwilSigner, Types, Utils }
+export { NodeKwil, WebKwil, KwilSigner, Types, Utils };

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -44,22 +44,3 @@ export function sha256BytesToBytes(message: Uint8Array): Uint8Array {
     shaObj.update(message);
     return shaObj.getHash('UINT8ARRAY');
 }
-
-export function generateSalt(length: number): Uint8Array {
-    if (typeof window !== 'undefined' && window.crypto && window.crypto.getRandomValues) {
-        // Browser environment with Web Crypto API
-        const salt = new Uint8Array(length);
-        const rand = window.crypto.getRandomValues(salt);
-        return rand;
-    } else if (typeof require !== 'undefined') {
-        // Assume Node.js environment
-        try {
-            const crypto = require('crypto');
-            return crypto.randomBytes(length);
-        } catch (err) {
-            throw new Error('Unable to generate salt in this environment.');
-        }
-    } else {
-        throw new Error('Unsupported environment.');
-    }
-}

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -17,6 +17,8 @@ const { KwilSigner } = require("../dist/core/kwilSigner")
 
 require("dotenv").config()
 
+const chainId = process.env.CHAIN_ID || "SHOULD FAIL"
+
 function logger(msg) {
     console.log(util.inspect(msg, false, null, true /* enable colors */))
 }
@@ -29,6 +31,7 @@ async function test() {
     
     const kwil = new kwiljs.NodeKwil({
         kwilProvider: process.env.KWIL_PROVIDER || "SHOULD FAIL",
+        chainId: chainId,
         timeout: 10000,
         logging: true,
     })
@@ -39,12 +42,13 @@ async function test() {
     const pubByte = hexToBytes(pubKey)
     const dbid = kwil.getDBID(pubByte, "mydb")
     // logger(dbid)
-    // broadcast(kwil, testDB, wallet, pubKey)
+    broadcast(kwil, testDB, wallet, pubKey)
     // await getTxInfo(kwil, txHash)
     // await getSchema(kwil, dbid)
     // getAccount(kwil, pubByte)
     // listDatabases(kwil, pubByte)
     // ping(kwil)
+    // chainInfo(kwil)
     // await execSingleAction(kwil, dbid, "add_post", wallet, pubByte)
     // await select(kwil, dbid, "SELECT * FROM posts")
     // select(kwil, dbid, `WITH RECURSIVE 
@@ -87,7 +91,10 @@ async function broadcast(kwil, tx, sig, pK) {
         .payload(ownedTx)
         .signer(sig)
         .publicKey(pK)
+        .chainId(chainId)
         .buildTx()
+
+    console.log(readytx)
 
     const txHash = await kwil.broadcast(readytx)
     logger(txHash)
@@ -101,6 +108,11 @@ async function listDatabases(kwil, owner) {
 async function ping(kwil) {
     const ping = await kwil.ping()
     logger(ping)
+}
+
+async function chainInfo(kwil) {
+    const info = await kwil.chainInfo();
+    logger(info)
 }
 
 async function getAction(kwil) {

--- a/tests/ethers5.test.ts
+++ b/tests/ethers5.test.ts
@@ -3,7 +3,7 @@ import { Types, Utils } from "../dist";
 import { AmntObject, kwil } from "./testingUtils";
 import { ActionBuilder } from "../dist/core/builders";
 import { ActionBuilderImpl } from "../dist/builders/action_builder";
-import { Transaction, TxReceipt } from "../dist/core/tx";
+import { BaseTransaction, Transaction, TxReceipt } from "../dist/core/tx";
 require('dotenv').config();
 
 const provider = process.env.ETH_PROVIDER === "https://provider.kwil.com" ? new providers.InfuraProvider("goerli") : process.env.ETH_PROVIDER ? new providers.JsonRpcProvider(process.env.ETH_PROVIDER) : new providers.JsonRpcProvider("http://localhost:8545");
@@ -23,6 +23,7 @@ describe("ActionBuilder + Transaction signing works with Ethersv5 Wallet and Sig
             .actionBuilder()
             .dbid(dbid)
             .name("add_post")
+            .chainId(process.env.CHAIN_ID as string)
 
         const count = await kwil.selectQuery(dbid, "SELECT COUNT(*) FROM posts");
         if (count.status == 200 && count.data) {
@@ -71,19 +72,19 @@ describe("ActionBuilder + Transaction signing works with Ethersv5 Wallet and Sig
         actionTx = await actionBuilder.buildTx();
 
         expect(actionTx).toBeDefined();
-        expect(actionTx).toBeInstanceOf(Transaction);
+        expect(actionTx).toBeInstanceOf(BaseTransaction);
         expect(actionTx.isSigned()).toBe(true);
     });
 
     test("All methods and getters on the Transaction class should return the correct values", () => {
         expect(actionTx).toBeDefined();
-        expect(actionTx).toBeInstanceOf(Transaction);
+        expect(actionTx).toBeInstanceOf(BaseTransaction);
         expect(actionTx.isSigned()).toBe(true);
         expect(actionTx.body.payload_type).toBeDefined();
         expect(actionTx.body.payload).toBeDefined();
         expect(actionTx.body.fee).toBeDefined();
         expect(actionTx.body.nonce).toBeGreaterThan(-1);
-        expect(actionTx.body.salt).toBeDefined();
+        expect(actionTx.body.chain_id).toBeDefined();
         expect(actionTx.sender).toBeDefined();
         expect(actionTx.isSigned()).toBe(true);
         expect(actionTx.signature).toBeDefined();

--- a/tests/testingUtils.ts
+++ b/tests/testingUtils.ts
@@ -61,6 +61,7 @@ export interface ActionObj {
 
 export const kwil = new NodeKwil({
     kwilProvider: process.env.KWIL_PROVIDER || "SHOULD FAIL",
+    chainId: process.env.CHAIN_ID || "SHOULD FAIL",
     timeout: 10000,
     logging: true
 })

--- a/tests/unitTests/api_client/api.test.ts
+++ b/tests/unitTests/api_client/api.test.ts
@@ -1,11 +1,11 @@
 import { mockedAxios, getMock, postMock, requestInterceptors } from './api-utils';
 import { Api } from '../../../src/api_client/api';
-import { Config } from '../../../src/api_client/config';
+import { ApiConfig, Config } from '../../../src/api_client/config';
 require('dotenv').config();
 
 
 class TestApi extends Api {
-    public constructor(host: string, opts: Config) {
+    public constructor(host: string, opts: ApiConfig) {
         super(host, opts);
     }
 }

--- a/tests/unitTests/builders/action_builder.test.ts
+++ b/tests/unitTests/builders/action_builder.test.ts
@@ -6,15 +6,17 @@ import { Wallet } from 'ethers';
 import { Transaction } from '../../../src/core/tx';
 import { Message } from '../../../src/core/message';
 import { ActionInput } from '../../../src/core/action';
-import { Account } from '../../../src/core/account';
+import { Account } from '../../../src/core/network';
 import { bytesToBase64 } from '../../../src/utils/base64';
 import { hexToBase64, stringToBytes } from '../../../src/utils/serial';
 import nacl from 'tweetnacl';
 import { SignatureType } from '../../../src/core/signature';
+import { BaseTransaction } from '../../../dist/core/tx';
+import { BytesEncodingStatus } from '../../../dist/core/enums';
 
 class TestKwil extends Kwil {
     public constructor() {
-        super({ kwilProvider: 'doesnt matter' });
+        super({ kwilProvider: 'doesnt matter', chainId: 'doesnt_matter' });
     }
 }
 
@@ -82,6 +84,14 @@ describe('ActionBuilder', () => {
             const result = actionBuilder.publicKey(pubKey);
             expect(result).toBe(actionBuilder);
             expect((actionBuilder as any)._publicKey).toBe(pubKey);
+        });
+    });
+
+    describe('chainId', () => {
+        it('should set the _chainId field and return actionBuilder', () => {
+            const result = actionBuilder.chainId('testChainId');
+            expect(result).toBe(actionBuilder);
+            expect((actionBuilder as any)._chainId).toBe('testChainId');
         });
     });
 
@@ -169,10 +179,10 @@ describe('ActionBuilder', () => {
                 .concat(actionInput)
                 .description('test')
                 .publicKey(pubKey)
+                .chainId('testChainId')
                 .buildTx();
 
             expect(result).toBeDefined();
-            expect(result).toBeInstanceOf(Transaction);
             expect(result.body.fee).toBe('100000');
             expect(result.body.description).toBe('test');
             expect(typeof result.signature.signature_bytes).toBe('string');
@@ -181,6 +191,8 @@ describe('ActionBuilder', () => {
             expect(result.sender).toBe(hexToBase64(pubKey));
             expect(result.body.payload_type).toBe('execute_action');
             expect(result.body.nonce).toBe(Number(mockedAccount.nonce) + 1);
+            expect(result.body.chain_id).toBe('testChainId');
+            expect(result.body.description).toBe('test');
             expect(result.serialization).toBe('concat')
         });
 
@@ -279,7 +291,7 @@ describe('buildMsg', () => {
 
         expect(msg).toBeDefined();
         expect(msg.body.payload).toBe("AAHeiHRlc3REYmlkjnRlc3RhY3Rpb25uYW1lxYR0ZXN0");
-        expect(msg.sender).toBe("")
+        expect(msg.sender).toBe(null)
         expect(msg.signature).toBeNull();
     });
 

--- a/tests/unitTests/builders/message_errors.test.ts
+++ b/tests/unitTests/builders/message_errors.test.ts
@@ -10,7 +10,7 @@ import { hexToBase64, stringToBytes } from "../../../src/utils/serial";
 
 class TestKwil extends Kwil {
     public constructor() {
-        super({ kwilProvider: 'doesnt matter' });
+        super({ kwilProvider: 'doesnt matter', chainId: 'doesnt matter' });
     }
 }
 
@@ -150,6 +150,6 @@ describe('buildMsg', () => {
             .name('testactionname')
             .dbid('testDbid')
             .signer(wallet)
-            .buildMsg()).rejects.toThrowError('Action testactionname requires inputs. Please provide inputs. With the ActionInput class and .concat method.');
+            .buildMsg()).rejects.toThrowError('No action data has been added to the ActionBuilder.');
     });
 });

--- a/tests/unitTests/builders/payload_builder.test.ts
+++ b/tests/unitTests/builders/payload_builder.test.ts
@@ -11,7 +11,7 @@ import { hexToBase64, stringToBytes, stringToHex } from '../../../src/utils/seri
 
 class TestKwil extends Kwil {
     constructor() {
-        super({kwilProvider: 'doesnt matter' })
+        super({kwilProvider: 'doesnt matter', chainId: 'doesnt matter' })
     }
 }
 
@@ -67,6 +67,14 @@ describe('Transaction Builder', () => {
         });
     });
 
+    describe('chainId', () => {
+        it('should set the chainId and return TxnBuilderImpl', () => {
+            const result = txBuilder.chainId('test');
+            expect(result).toBeInstanceOf(PayloadBuilderImpl);
+            expect((result as any)._chainId).toBe('test');
+        });
+    });
+
     describe('description', () => {
         it('should set the description and return TxnBuilderImpl', () => {
             const result = txBuilder.description('test');
@@ -104,6 +112,7 @@ describe('Transaction Builder', () => {
                 .payloadType(PayloadType.EXECUTE_ACTION)
                 .publicKey(pubKey)
                 .description('test')
+                .chainId('test')
                 .signer(wallet, SignatureType.SECP256K1_PERSONAL)
                 .buildTx();
 
@@ -113,8 +122,9 @@ describe('Transaction Builder', () => {
             expect(result.body.fee).toBe('100000');
             expect(result.body.nonce).toBe(2);
             expect(typeof result.body.payload).toBe('string');
-            expect(typeof result.body.salt).toBe('string');
+            expect(result.body.chain_id).toBe('test');
             expect(result.isSigned()).toBe(true);
+
             expect(result.sender).toBe(hexToBase64(pubKey));
             expect(result.signature.signature_type).toBe('secp256k1_ep');
             expect(typeof result.signature.signature_bytes).toBe('string');

--- a/tests/unitTests/client/intern.test.ts
+++ b/tests/unitTests/client/intern.test.ts
@@ -4,7 +4,7 @@ import Client from "../../../src/api_client/client";
 
 class TestKwil extends Kwil {
     constructor() {
-        super({ kwilProvider: 'doesnt matter' })
+        super({ kwilProvider: 'doesnt matter', chainId: 'doesnt matter' })
     }
 }
 

--- a/tests/unitTests/core/message.test.ts
+++ b/tests/unitTests/core/message.test.ts
@@ -1,12 +1,12 @@
 import { SerializationType } from '../../../src/core/enums';
-import { Message, Msg } from '../../../src/core/message';
+import { BaseMessage, Message, Msg } from '../../../src/core/message';
 import { SignatureType } from '../../../src/core/signature';
 
 describe('Message class methods with signature should all work', () => {
     let msg: Message;
 
     test('Message constructor should work', () => {
-        msg = new Message({
+        msg = new BaseMessage({
             body: {
                 description: "description",
                 payload: "payload"


### PR DESCRIPTION
…uctor

In the `WebKwil` or `NodeKwil` constructor, you must now pass a `chainId` property for the Kwil chain you are connecting to. The chainId is included in the transaction payload when state-changing transactions are built / executed.

BREAKING CHANGE: The `WebKwil` and `NodeKwil` classes require an additional `chainId` config string to execute database deploys, database drops, or state-changing actions. You can check the chainId for your kwilProvider by calling `kwil.chainInfo()`.

re #39

closes #39 