### PR TITLE
fix(client/kwil.ts): deprecate builders and clean Utils namespace

### DIFF
--- a/src/client/kwil.ts
+++ b/src/client/kwil.ts
@@ -111,6 +111,7 @@ export abstract class Kwil {
    * Returns an instance of ActionBuilder for this client.
    *
    * @returns An ActionBuilder instance. ActionBuilder is used to build action transactions to be broadcasted to the Kwil network.
+   * @deprecated Use `kwil.execute()` or `kwil.call()` instead. See: {@link https://github.com/kwilteam/kwil-js/issues/32}.
    */
 
   public actionBuilder(): NonNil<ActionBuilder> {
@@ -121,6 +122,7 @@ export abstract class Kwil {
    * Returns an instance of DBBuilder for this client.
    *
    * @returns A DBBuilder instance. DBBuilder is used to build new database transactions to be broadcasted to the Kwil network.
+   * @deprecated Use `kwil.deploy()` See: {@link https://github.com/kwilteam/kwil-js/issues/32}.
    */
 
   public dbBuilder(): NonNil<DBBuilder<PayloadType.DEPLOY_DATABASE>> {
@@ -131,6 +133,7 @@ export abstract class Kwil {
    * Returns an instance of Drop Database Builder for this client.
    *
    * @returns A Drop Database Builder instance. Drop Database Builder is used to build drop database transactions to be broadcasted to the Kwil network.
+   * @deprecated Use `kwil.drop()` See: {@link https://github.com/kwilteam/kwil-js/issues/32}.
    */
 
   public dropDbBuilder(): NonNil<DBBuilder<PayloadType.DROP_DATABASE>> {
@@ -142,6 +145,7 @@ export abstract class Kwil {
    *
    * @param tx - The transaction to broadcast. The transaction can be built using the ActionBuilder or DBBuilder.
    * @returns A promise that resolves to the receipt of the transaction. The transaction receipt includes the transaction hash, fee, and body.
+   * @deprecated Use `kwil.execute()` or `kwil.deploy()` instead. See: {@link https://github.com/kwilteam/kwil-js/issues/32}.
    */
 
   public async broadcast(
@@ -255,7 +259,7 @@ export abstract class Kwil {
       return await this.client.call(actionBody);
     }
 
-    let msg = this.actionBuilder()
+    let msg = ActionBuilderImpl.of(this).chainId(this.chainId)
       .dbid(actionBody.dbid)
       .name(actionBody.action)
       .description(actionBody.description || '');

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { NodeKwil } from './client/node/nodeKwil';
 import { WebKwil } from './client/web/webKwil';
-import { generateDBID } from './utils/dbid';
+import { generateDBID as _generateDBID} from './utils/dbid';
 import { TxReceipt as _TxReceipt } from './core/tx';
 import { ActionBuilder as _ActionBuilder, DBBuilder as _DBBuilder } from './core/builders';
 import { ActionInput as _ActionInput, ActionBody as _ActionBody } from './core/action';
@@ -24,7 +24,7 @@ import { GenericResponse as _GenericResponse } from './core/resreq';
 import { TxResult as _TxResult, TxInfoReceipt as _TxInfoReceipt } from './core/txQuery';
 import { Account as _Account } from './core/network';
 import { MsgReceipt as _MsgReceipt, Message as _Message } from './core/message';
-import { recoverSecp256k1PubKey } from './utils/keys';
+import { recoverSecp256k1PubKey as _recoverSecp256k1PubKey } from './utils/keys';
 import { KwilSigner } from './core/kwilSigner';
 import { DeployOrDrop, PayloadType as _PayloadType } from './core/enums';
 
@@ -57,22 +57,22 @@ namespace Types {
   export type ActionBody = _ActionBody;
 }
 
-const ActionInput = _ActionInput;
-
-const Utils = {
+namespace Utils {
   /**
    * `ActionInput` class is a utility class for creating action inputs.
    */
-  ActionInput,
+  export class ActionInput extends _ActionInput {}
+  
   /**
-   * Generates a unique database identifier (DBID) from the provided owner's Ethereum wallet address and a database name.
+   * Generates a unique database identifier (DBID) from the provided owner's public key and a database name.
    */
-  generateDBID,
+  export const generateDBID = _generateDBID;
+  
   /**
    * Recovers the public key from a signature and a message for Secp256k1 Public Keys (EVM Networks).
    * @param signer - The signer for the action. This must be a valid Ethereum signer from Ethers v5 or Ethers v6.
    */
-  recoverSecp256k1PubKey,
-};
+  export const recoverSecp256k1PubKey = _recoverSecp256k1PubKey;
+}
 
 export { NodeKwil, WebKwil, KwilSigner, Types, Utils };

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -35,7 +35,7 @@ async function test() {
         timeout: 10000,
         logging: true,
     })
-
+    
     const pubKey = await recoverPubKey(wallet)
     const kwilSigner = new KwilSigner(wallet, pubKey)
 

--- a/testing-functions/ts_test.ts
+++ b/testing-functions/ts_test.ts
@@ -6,7 +6,8 @@ import compiledKf from "./mydb.json";
 require('dotenv').config()
 
 const kwil = new NodeKwil({
-    kwilProvider: "http://localhost:8080"
+    kwilProvider: "http://localhost:8080",
+    chainId: ""
 })
 
 const provider = new JsonRpcProvider(process.env.ETH_PROVIDER)
@@ -14,7 +15,7 @@ const wallet = new Wallet(process.env.PRIVATE_KEY as string, provider)
 
 async function buildSigner() {
     const pk = await Utils.recoverSecp256k1PubKey(wallet);
-    return new KwilSigner(pk, wallet);
+    return new KwilSigner(wallet, pk);
 }
 
 async function main() {


### PR DESCRIPTION
* add deprecation notice for the `kwil.actionBuilder()`, `kwil.dbBuilder()`, `kwil.dropDbBuilder()` and `kwil.broadcast()` in favor of using `kwil.execute()`, `kwil.deploy()`, `kwil.drop()`, and `kwil.call()`.

* Cleaned up the Utils namespace to inherit class types.

BREAKING CHANGE: The `kwil.actionBuilder()`, `kwil.dbBuilder()`, `kwil.dropDbBuilder()` and `kwil.broadcast()` are deprecated in favor of using `kwil.execute()`, `kwil.deploy()`, `kwil.drop()`, and `kwil.call()`. The deprecated methods will be removed in Q1 2024.

re #32