### PR TITLE
feat(builders/payload_builder): max length to signature descriptions

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -200,10 +200,11 @@ const kwilSigner = new KwilSigner(signer, publicKey);
 If you wish to sign with something other than an EtherJS signer, you may pass a callback function that accepts and returns a `Uint8Array()` and the enumerator for the signature type used.
 
 Currently, Kwil supports two signature types:
-| Type  | Enumerator |
-|:----- |:------:|
-| Secp256k1  | 'secp256k1_ep'     |
-| Ed25519    | 'ed25519'     |
+
+| Type      |   Enumerator   | Description |
+| :-------- | :------------: | ----------- |
+| Secp256k1 | 'secp256k1_ep' | The Kwil Signer will use a secp256k1 elliptic curve signature, which is the same signature used in Ethereum's [personal sign](https://eips.ethereum.org/EIPS/eip-191). |
+| Ed25519   |   'ed25519'    | The Kwil Signer will use an ed25519 signature. |
 
 To use an ed25519 signature:
 

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ If you wish to sign with something other than an EtherJS signer, you may pass a 
 
 Currently, Kwil supports two signature types:
 
-| Type  | Enumerator |
-|:----- |:------:|
-| Secp256k1  | 'secp256k1_ep' |
-| Ed25519    | 'ed25519' |
+| Type      |   Enumerator   | Description |
+| :-------- | :------------: | ----------- |
+| Secp256k1 | 'secp256k1_ep' | The Kwil Signer will use a secp256k1 elliptic curve signature. |
+| Ed25519   |   'ed25519'    | The Kwil Signer will use an ed25519 signature. |
 
 To use an ed25519 signature:
 
@@ -139,7 +139,7 @@ const dbid = kwil.getDBID("publicKey", "database_name")
 const actionBody = {
     dbid,
     action: "your_action_name",
-    inputs: input,
+    inputs: [ input ],
     description: "Click sign to execute the action!"
 }
 
@@ -178,7 +178,7 @@ const dbid = kwil.getDBID("public_key", "database_name")
 const actionBody = {
     dbid,
     action: "your_action_name",
-    inputs: input
+    inputs: [ input ]
 }
 
 // pass action body to execute method

--- a/src/builders/payload_builder.ts
+++ b/src/builders/payload_builder.ts
@@ -145,7 +145,11 @@ export class PayloadBuilderImpl implements PayloadBuilder {
     // assign description if it is not null or undefined
     // we do not want to throw an error if null because description is optional. The default value is empty string.
     if (description) {
-      this._description = description;
+      this._description = objects.requireMaxLength(
+        description,
+        200,
+        `signature description cannot be longer than 200 characters. You provided ${description.length} characters.`
+      );
     }
     return this;
   }

--- a/src/utils/objects.ts
+++ b/src/utils/objects.ts
@@ -57,5 +57,16 @@ export const objects = {
 
         throw new Error("value is not a number, it is a " + typeof value);
     },
+    requireMaxLength: <T>(value: T, maxLength: number, message?: string | ((v: T) => Error)): NonNil<T> => {
+        if (value && value.toString().length > maxLength) {
+            if (typeof message === 'function') {
+                throw message(value);
+            }
+
+            throw new Error(message || `value is longer than ${maxLength} characters`);
+        }
+
+        return value as NonNil<T>;
+    }
 };
 

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -42,7 +42,7 @@ async function test() {
     const pubByte = hexToBytes(pubKey)
     const dbid = kwil.getDBID(pubByte, "mydb")
     // logger(dbid)
-    broadcast(kwil, testDB, wallet, pubKey)
+    // broadcast(kwil, testDB, wallet, pubKey)
     // await getTxInfo(kwil, txHash)
     // await getSchema(kwil, dbid)
     // getAccount(kwil, pubByte)

--- a/tests/kwil.test.ts
+++ b/tests/kwil.test.ts
@@ -332,12 +332,12 @@ describe("ActionBuilder + ActionInput + Transaction public methods & broadcastin
         expect(actionInputArr).toBeDefined();
         expect(actionInputArr).toBeInstanceOf(Array);
         expect(actionInputArr).toHaveLength(2);
-        expect(actionInputArr[0]).toBeInstanceOf(Utils.ActionInput);
+        expect(actionInputArr[0]).toBeInstanceOf(ActionInput);
         expect(actionInputArr[0].get("$id")).toBe(recordCount + 2);
         expect(actionInputArr[0].get("$user")).toBe("Luke");
         expect(actionInputArr[0].get("$title")).toBe("Test Post");
         expect(actionInputArr[0].get("$body")).toBe("This is a test post");
-        expect(actionInputArr[1]).toBeInstanceOf(Utils.ActionInput);
+        expect(actionInputArr[1]).toBeInstanceOf(ActionInput);
         expect(actionInputArr[1].get("$id")).toBe(recordCount + 3);
         expect(actionInputArr[1].get("$user")).toBe("Luke");
         expect(actionInputArr[1].get("$title")).toBe("Test Post");
@@ -355,7 +355,7 @@ describe("ActionBuilder + ActionInput + Transaction public methods & broadcastin
         ]);
 
         expect(staticActionInputFrom).toBeDefined();
-        expect(staticActionInputFrom).toBeInstanceOf(Utils.ActionInput);
+        expect(staticActionInputFrom).toBeInstanceOf(ActionInput);
         expect(staticActionInputFrom.get("$id")).toBe(recordCount + 4);
         expect(staticActionInputFrom.get("$user")).toBe("Luke");
         expect(staticActionInputFrom.get("$title")).toBe("Test Post");
@@ -375,7 +375,7 @@ describe("ActionBuilder + ActionInput + Transaction public methods & broadcastin
         staticActionInputFromObject = Utils.ActionInput.fromObject(obj);
 
         expect(staticActionInputFromObject).toBeDefined();
-        expect(staticActionInputFromObject).toBeInstanceOf(Utils.ActionInput);
+        expect(staticActionInputFromObject).toBeInstanceOf(ActionInput);
         expect(staticActionInputFromObject.get("$id")).toBe(recordCount + 5);
         expect(staticActionInputFromObject.get("$user")).toBe("Luke");
         expect(staticActionInputFromObject.get("$title")).toBe("Test Post");
@@ -402,12 +402,12 @@ describe("ActionBuilder + ActionInput + Transaction public methods & broadcastin
         expect(staticActionInputFromObjects).toBeDefined();
         expect(staticActionInputFromObjects).toBeInstanceOf(Array);
         expect(staticActionInputFromObjects).toHaveLength(2);
-        expect(staticActionInputFromObjects[0]).toBeInstanceOf(Utils.ActionInput);
+        expect(staticActionInputFromObjects[0]).toBeInstanceOf(ActionInput);
         expect(staticActionInputFromObjects[0].get("$id")).toBe(recordCount + 6);
         expect(staticActionInputFromObjects[0].get("$user")).toBe("Luke");
         expect(staticActionInputFromObjects[0].get("$title")).toBe("Test Post");
         expect(staticActionInputFromObjects[0].get("$body")).toBe("This is a test post");
-        expect(staticActionInputFromObjects[1]).toBeInstanceOf(Utils.ActionInput);
+        expect(staticActionInputFromObjects[1]).toBeInstanceOf(ActionInput);
         expect(staticActionInputFromObjects[1].get("$id")).toBe(recordCount + 7);
         expect(staticActionInputFromObjects[1].get("$user")).toBe("Luke");
         expect(staticActionInputFromObjects[1].get("$title")).toBe("Test Post");
@@ -418,7 +418,7 @@ describe("ActionBuilder + ActionInput + Transaction public methods & broadcastin
         const result = Utils.ActionInput.of();
 
         expect(result).toBeDefined();
-        expect(result).toBeInstanceOf(Utils.ActionInput);
+        expect(result).toBeInstanceOf(ActionInput);
         expect(result.get("$id")).toBeUndefined();
         expect(result.get("$user")).toBeUndefined();
         expect(result.get("$title")).toBeUndefined();
@@ -434,7 +434,7 @@ describe("ActionBuilder + ActionInput + Transaction public methods & broadcastin
             .put("$body", "This is a test post");
 
         expect(staticActionInputOf).toBeDefined();
-        expect(staticActionInputOf).toBeInstanceOf(Utils.ActionInput);
+        expect(staticActionInputOf).toBeInstanceOf(ActionInput);
         expect(staticActionInputOf.get("$id")).toBe(recordCount + 8);
         expect(staticActionInputOf.get("$user")).toBe("Luke");
         expect(staticActionInputOf.get("$title")).toBe("Test Post");
@@ -1069,10 +1069,10 @@ describe("Testing simple actions and db deploy / drop (builder pattern alternati
                 dbid,
                 action: "add_post",
                 inputs: [{
-                    "$id": recordCount,
-                    "$user": "Luke",
-                    "$title": "Test Post",
-                    "$body": "This is a test post"
+                    $id: recordCount,
+                    $user: "Luke",
+                    $title: "Test Post",
+                    $body: "This is a test post"
                 }],
                 description: "This is a test action"
             }

--- a/tests/unitTests/builders/payload_builder.test.ts
+++ b/tests/unitTests/builders/payload_builder.test.ts
@@ -81,6 +81,10 @@ describe('Transaction Builder', () => {
             expect(result).toBeInstanceOf(PayloadBuilderImpl);
             expect((result as any)._description).toBe('test');
         });
+
+        it('should throw an error if description is more than 200 chars', () => {
+            expect(() => txBuilder.description('a'.repeat(201))).toThrowError();
+        })
     });
 
     describe('buildTx', () => {


### PR DESCRIPTION
Added a max length of 200 characters to description. The SDK will throw an error if the user passes a description of more than 200 characters.

BREAKING CHANGE: Signature descriptions cannot be longer than 200 characters. Any signature description that was previously >200 characters will now trigger an error.

closes #26