### PR TITLE
fix(builders/payload_builder): remove the 🪶  in the Kwil signature

### DIFF
--- a/src/builders/payload_builder.ts
+++ b/src/builders/payload_builder.ts
@@ -342,9 +342,8 @@ PayloadType: ${tx.body.payload_type}
 PayloadDigest: ${bytesToHex(digest)}
 Fee: ${tx.body.fee}
 Nonce: ${tx.body.nonce}
-Chain ID: ${tx.body.chain_id}
 
-Kwil 🖋
+Kwil Chain ID: ${tx.body.chain_id}
 `;
 
     // sign the above message
@@ -408,8 +407,6 @@ Kwil 🖋
 DBID: ${msg.body.payload?.dbid}
 Action: ${msg.body.payload?.action}
 PayloadDigest: ${bytesToHex(digest)}
-
-Kwil 🖋
 `;
     // sign the above message
     const signedMessage = await executeSign(stringToBytes(signatureMessage), signer, signatureType);

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -27,7 +27,7 @@ async function test() {
     //update to goerli when live
     const provider = new ethers.JsonRpcProvider(process.env.ETH_PROVIDER)
     const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider)
-    const txHash = '3b1afbf33ae847f65945b478c347ebdd2b5e8fd6b69fd244a8fd1273cfa03cb4'
+    const txHash = '4357e7174f61db9b79ea35e8090bb350bf474195c78ab3af159241a891bbebe1'
     
     const kwil = new kwiljs.NodeKwil({
         kwilProvider: process.env.KWIL_PROVIDER || "SHOULD FAIL",

--- a/tests/unitTests/builders/action_builder.test.ts
+++ b/tests/unitTests/builders/action_builder.test.ts
@@ -3,7 +3,6 @@ import { ActionBuilderImpl } from '../../../src/builders/action_builder';
 import { ActionBuilder } from '../../../src/core/builders';
 import { Kwil } from '../../../src/client/kwil';
 import { Wallet } from 'ethers';
-import { Transaction } from '../../../src/core/tx';
 import { Message } from '../../../src/core/message';
 import { ActionInput } from '../../../src/core/action';
 import { Account } from '../../../src/core/network';
@@ -11,8 +10,6 @@ import { bytesToBase64 } from '../../../src/utils/base64';
 import { hexToBase64, stringToBytes } from '../../../src/utils/serial';
 import nacl from 'tweetnacl';
 import { SignatureType } from '../../../src/core/signature';
-import { BaseTransaction } from '../../../dist/core/tx';
-import { BytesEncodingStatus } from '../../../dist/core/enums';
 
 class TestKwil extends Kwil {
     public constructor() {


### PR DESCRIPTION
remove the 'Kwil 🪶' in the transaction and message signature, and added the "Kwil Chain ID syntax" as implemented in this PR: https://github.com/kwilteam/kwil-db/pull/368