### PR TITLE
fix(client/kwil.ts): add wrapped config property to kwil class

### DIFF
--- a/src/client/intern.ts
+++ b/src/client/intern.ts
@@ -1,16 +1,34 @@
-import { Transaction } from "../core/tx";
-import { GenericResponse } from "../core/resreq";
-import { Kwil } from "./kwil";
-import { objects } from "../utils/objects";
+import { Transaction } from '../core/tx';
+import { GenericResponse } from '../core/resreq';
+import { Kwil } from './kwil';
+import { objects } from '../utils/objects';
+import { Config } from '../api_client/config';
 
-const key = Symbol();
+const estimateKey = Symbol('estimate');
 
-export function unwrap<T>(kwil: Kwil): ((tx: Transaction) => Promise<GenericResponse<string>>) {
-    objects.requireNonNil(kwil);
-    return objects.requireNonNil((kwil as any)[key]);
+export function unwrapEstimate<T>(
+  kwil: Kwil
+): (tx: Transaction) => Promise<GenericResponse<string>> {
+  objects.requireNonNil(kwil);
+  return objects.requireNonNil((kwil as any)[estimateKey]);
 }
 
-export function wrap<T>(kwil: Kwil, method: (tx: Transaction) => Promise<GenericResponse<string>>): void {
-    objects.requireNonNil(kwil);
-    (kwil as any)[key] = method
+export function wrapEstimate<T>(
+  kwil: Kwil,
+  method: (tx: Transaction) => Promise<GenericResponse<string>>
+): void {
+  objects.requireNonNil(kwil);
+  (kwil as any)[estimateKey] = method;
+}
+
+const configKey = Symbol('config');
+
+export function unwrapConfig(kwil: Kwil): Config {
+  objects.requireNonNil(kwil);
+  return objects.requireNonNil((kwil as any)[configKey]);
+}
+
+export function wrapConfig(kwil: Kwil, config: Config): void {
+  objects.requireNonNil(kwil);
+  (kwil as any)[configKey] = config;
 }

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -35,7 +35,7 @@ async function test() {
         timeout: 10000,
         logging: true,
     })
-    
+
     const pubKey = await recoverPubKey(wallet)
     const kwilSigner = new KwilSigner(wallet, pubKey)
 

--- a/tests/unitTests/client/intern.test.ts
+++ b/tests/unitTests/client/intern.test.ts
@@ -1,6 +1,7 @@
-import { wrap, unwrap } from "../../../src/client/intern";
+import { wrapEstimate, unwrapEstimate, wrapConfig, unwrapConfig } from "../../../src/client/intern";
 import { Kwil } from "../../../src/client/kwil";
 import Client from "../../../src/api_client/client";
+import { Config } from "../../../src/api_client/config";
 
 class TestKwil extends Kwil {
     constructor() {
@@ -8,19 +9,35 @@ class TestKwil extends Kwil {
     }
 }
 
-describe("client/intern", () => {
+describe("client/intern - estimates", () => {
 
     const testClient = new Client({ kwilProvider: 'doesnt matter' });
 
     it('wrap should wrap Kwil client', () => {
         const kwil = new TestKwil();
-        const wrapped = wrap(kwil, testClient.estimateCost);
+        const wrapped = wrapEstimate(kwil, testClient.estimateCost);
         expect(wrapped).toBe(undefined);
     })
 
     it('unwrap should unwrap Kwil client etimate cost method', () => {
         const kwil = new TestKwil();
-        const unwrapped = unwrap(kwil);
+        const unwrapped = unwrapEstimate(kwil);
         expect(typeof unwrapped).toBe('function');
+    });
+});
+
+describe("client/intern - config", () => {
+    const config: Config = { kwilProvider: 'doesnt matter', chainId: 'doesnt matter' };
+
+    it('wrap should wrap Kwil client to store configs', () => {
+        const kwil = new TestKwil();
+        const wrapped = wrapConfig(kwil, config);
+        expect(wrapped).toBe(undefined);
+    })
+
+    it('unwrap should unwrap Kwil client to expose configs', () => {
+        const kwil = new TestKwil();
+        const unwrapped = unwrapConfig(kwil);
+        expect(unwrapped).toStrictEqual(config);
     });
 });


### PR DESCRIPTION
add config symbol to kwil class, allowing for configs to be accessed when the Kwil class is extended