### PR TITLE
feat: change ethereum identifier to wallet address

### DIFF
--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -105,13 +105,13 @@ export default class Client extends Api {
 
     let acct: Account = {
       balance: '',
-      public_key: new Uint8Array(),
+      identifier: new Uint8Array(),
       nonce: '',
     };
 
     if (res.data) {
       acct.balance = res.data.account.balance;
-      acct.public_key = base64ToBytes(res.data.account.public_key as string);
+      acct.identifier = base64ToBytes(res.data.account.identifier as string);
       acct.nonce = res.data.account.nonce;
     }
 

--- a/src/builders/db_builder.ts
+++ b/src/builders/db_builder.ts
@@ -21,7 +21,7 @@ export class DBBuilderImpl<T extends DeployOrDrop, U extends EnvironmentType> im
   private _signer: Nillable<SignerSupplier> = null;
   private _signatureType: Nillable<AnySignatureType>;
   private _payloadType: Nillable<PayloadType> = null;
-  private _publicKey: Nillable<string | Uint8Array> = null;
+  private _identifier: Nillable<string | Uint8Array> = null;
   private _chainId: Nillable<string> = null;
   private _description: Nillable<string> = null;
 
@@ -119,17 +119,17 @@ export class DBBuilderImpl<T extends DeployOrDrop, U extends EnvironmentType> im
   }
 
   /**
-   * Specifies the public key for the database deployment / drop.
+   * Specifies the identifier (e.g. wallet, public key, etc) for the database deployment / drop.
    *
-   * @param {string | Uint8Array} publicKey - The public key for the database deployment / drop.
+   * @param {string | Uint8Array} identifier - The identifier for the database deployment / drop.
    * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-   * @throws Will throw an error if the public key is null or undefined.
+   * @throws Will throw an error if the identifier is null or undefined.
    */
-  publicKey(publicKey: string | Uint8Array): NonNil<DBBuilder<T>> {
-    // throw runtime error if public key is null
-    this._publicKey = objects.requireNonNil(
-      publicKey,
-      'public key is required for DbBuilder. Please pass a valid public key.'
+  publicKey(identifier: string | Uint8Array): NonNil<DBBuilder<T>> {
+    // throw runtime error if identifier is null
+    this._identifier = objects.requireNonNil(
+      identifier,
+      'identifier is required for DbBuilder. Please pass a valid identifier to the .publicKey() method.'
     );
     return this;
   }
@@ -197,9 +197,9 @@ export class DBBuilderImpl<T extends DeployOrDrop, U extends EnvironmentType> im
       this._signer,
       'signer cannot be null or undefined. please specify a signer.'
     );
-    const publicKey = objects.requireNonNil(
-      this._publicKey,
-      'public key cannot be null or undefined. please specify a public key.'
+    const identifier = objects.requireNonNil(
+      this._identifier,
+      'identifier cannot be null or undefined. please specify a identifier.'
     );
     const chainId = objects.requireNonNil(
       this._chainId,
@@ -214,7 +214,7 @@ export class DBBuilderImpl<T extends DeployOrDrop, U extends EnvironmentType> im
       .payloadType(payloadType)
       .payload(cleanedPayload)
       .signer(signer, signatureType)
-      .publicKey(publicKey)
+      .publicKey(identifier)
       .chainId(chainId)
       .description(this._description);
     return tx.buildTx();

--- a/src/core/builders.ts
+++ b/src/core/builders.ts
@@ -38,13 +38,13 @@ export interface PayloadBuilder {
   signer(signer: SignerSupplier, sigType: AnySignatureType): NonNil<PayloadBuilder>;
 
   /**
-   * Specify the public key for the payload signer.
+   * Specifies the identifier (e.g. wallet, public key, etc) for the payload signer.
    *
-   * @param {HexString | Uint8Array} publicKey - The public key to be used to sign the transaction. This can be a hex string or a Uint8Array.
+   * @param {HexString | Uint8Array} identifier - The identifier to be used to sign the transaction. This can be a hex string or a Uint8Array.
    * @returns {PayloadBuilder} - The current `PayloadBuilder` instance for chaining.
-   * @throws {Error} - If the public key is null or undefined.
+   * @throws {Error} - If the identifier is null or undefined.
    */
-  publicKey(publicKey: HexString | Uint8Array): NonNil<PayloadBuilder>;
+  publicKey(identifier: HexString | Uint8Array): NonNil<PayloadBuilder>;
 
   /**
    * Set the description to be included in the payload signature.
@@ -137,13 +137,13 @@ export interface DBBuilder<T extends DeployOrDrop> {
   payload(payload: DbPayloadType<T>): NonNil<DBBuilder<T>>;
 
   /**
-   * Specifies the public key for the database deployment / drop.
+   * Specifies the identifier (e.g. wallet, public key, etc) for the database deployment / drop.
    *
-   * @param {HexString | Uint8Array} publicKey - The public key for the database deployment / drop.
+   * @param {string | Uint8Array} identifier - The identifier for the database deployment / drop.
    * @returns {DBBuilder} The current `DBBuilder` instance for chaining.
-   * @throws Will throw an error if the public key is null or undefined.
+   * @throws Will throw an error if the identifier is null or undefined.
    */
-  publicKey(publicKey: HexString | Uint8Array): NonNil<DBBuilder<T>>;
+  publicKey(identifier: HexString | Uint8Array): NonNil<DBBuilder<T>>;
 
   /**
    * Specifies the chain ID for the network being used.
@@ -244,14 +244,14 @@ export interface ActionBuilder {
   signer(signer: SignerSupplier, signatureType?: AnySignatureType): NonNil<ActionBuilder>;
 
   /**
-   * Specifies the public key of the wallet signing for the database operation.
+   * Specifies the identifier (e.g. wallet, public key, etc) of the signer for the action.
    *
-   * @param {HexString | Uint8Array} publicKey - The public key of the wallet signing for the database operation.
+   * @param {HexString | Uint8Array} identifier - The identifier of the wallet signing for the database operation.
    * @returns {ActionBuilder} The current `ActionBuilder` instance for chaining.
    * @throws Will throw an error if the value is specified while the action is being built.
-   * @throws Will throw an error if the public key is null or undefined.
+   * @throws Will throw an error if the identifier is null or undefined.
    */
-  publicKey(publicKey: HexString | Uint8Array): NonNil<ActionBuilder>;
+  publicKey(identifier: HexString | Uint8Array): NonNil<ActionBuilder>;
 
   /**
    * Specifies the description to be included in the message that is signed.

--- a/src/core/kwilSigner.ts
+++ b/src/core/kwilSigner.ts
@@ -1,59 +1,70 @@
-import { hexToBytes } from "../utils/serial";
-import { HexString } from "../utils/types";
-import { CustomSigner, EthSigner, SignerSupplier } from "./builders";
-import { AnySignatureType, SignatureType, getSignatureType } from "./signature";
+import { hexToBytes } from '../utils/serial';
+import { HexString } from '../utils/types';
+import { CustomSigner, EthSigner, SignerSupplier } from './builders';
+import { AnySignatureType, SignatureType, getSignatureType } from './signature';
 
 /**
  * The `KwilSigner` class is a utility class for storing a signer and its associated public key. It is used to sign transactions and messages on Kwil.
  */
 export class KwilSigner {
-    /** The signer, which can be of type `EthSigner` or `CustomSigner` */
-    public readonly signer: EthSigner | CustomSigner;
+  /** The signer, which can be of type `EthSigner` or `CustomSigner` */
+  public readonly signer: EthSigner | CustomSigner;
 
-    /** The public key associated with the signer */
-    public readonly publicKey: Uint8Array;
+  /** The identifier associated with the signer (e.g. wallet address, public key, etc). */
+  public readonly identifier: Uint8Array;
 
-    /** The type of the signature. */
-    public readonly signatureType: AnySignatureType;
+  /** The type of the signature. */
+  public readonly signatureType: AnySignatureType;
 
-    /**
-     * Creates a new instance of KwilSigner using an EthSigner.
-     * 
-     * @param {EthSigner} signer - A signer from Ethers v5 or Ethers v6.
-     * @param {HexString | Uint8Array} publicKey - The public key associated with the signer. Can be a hex string or bytes (Uint8Array).
-     */
-    constructor(signer: EthSigner, publicKey: HexString | Uint8Array);
+  /**
+   * Creates a new instance of KwilSigner using an EthSigner.
+   *
+   * @param {EthSigner} signer - A signer from Ethers v5 or Ethers v6.
+   * @param {HexString | Uint8Array} identifier - The wallet address associated with the signer. Can be a hex string or bytes (Uint8Array).
+   */
+  constructor(signer: EthSigner, identifier: HexString | Uint8Array);
 
-    /**
-     * Creates a new instance of KwilSigner using a CustomSigner with a specified signature type.
-     * 
-     * @param {CustomSigner} signer - An instance of CustomSigner.
-     * @param {HexString | Uint8Array} publicKey - The public key associated with the signer. Can be a hex string or bytes (Uint8Array).
-     * @param {AnySignatureType} signatureType - The type of the signature. Can be from the SignatureType enum or a custom string for the signer name, if implemented on the Kwil network.
-     */
-    constructor(signer: CustomSigner, publicKey: HexString | Uint8Array, signatureType: AnySignatureType);
+  /**
+   * Creates a new instance of KwilSigner using a CustomSigner with a specified signature type.
+   *
+   * @param {CustomSigner} signer - An instance of CustomSigner.
+   * @param {HexString | Uint8Array} identifier - The identifier associated with the signer (e.g. wallet address, public key, etc). Can be a hex string or bytes (Uint8Array).
+   * @param {AnySignatureType} signatureType - The type of the signature. Can be from the SignatureType enum or a custom string for the signer name, if implemented on the Kwil network.
+   */
+  constructor(
+    signer: CustomSigner,
+    identifier: HexString | Uint8Array,
+    signatureType: AnySignatureType
+  );
 
-    /**
-     * Actual implementation of the KwilSigner constructor.
-     * 
-     * @param {SignerSupplier} signer - Either an instance of EthSigner or CustomSigner.
-     * @param {HexString | Uint8Array} publicKey - The public key associated with the signer. Can be a hex string or bytes (Uint8Array).
-     * @param {AnySignatureType} signatureType - (Optional) The type of the signature. If not provided, 
-     *                        the signature type is determined from the signer.
-     */
-    constructor(signer: SignerSupplier, publicKey: HexString | Uint8Array, signatureType?: AnySignatureType) {
-        this.signer = signer;
-        if(typeof publicKey === "string") {
-            this.publicKey = hexToBytes(publicKey)
-        } else {
-            this.publicKey = publicKey;
-        }
-        if (signatureType) {
-            this.signatureType = signatureType;
-        } else {
-            this.signatureType = getSignatureType(signer);
-            if(this.signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
-                throw new Error("Could not determine signature type from signer. Please pass a signature type to the KwilSigner constructor.");
-            }
-    }}
-} 
+  /**
+   * Actual implementation of the KwilSigner constructor.
+   *
+   * @param {SignerSupplier} signer - Either an instance of EthSigner or CustomSigner.
+   * @param {HexString | Uint8Array} identifier - The identifier associated with the signer (e.g. wallet address, public key, etc). Can be a hex string or bytes (Uint8Array).
+   * @param {AnySignatureType} signatureType - (Optional) The type of the signature. If not provided,
+   *                        the signature type is determined from the signer.
+   */
+  constructor(
+    signer: SignerSupplier,
+    identifier: HexString | Uint8Array,
+    signatureType?: AnySignatureType
+  ) {
+    this.signer = signer;
+    if (typeof identifier === 'string') {
+      this.identifier = hexToBytes(identifier);
+    } else {
+      this.identifier = identifier;
+    }
+    if (signatureType) {
+      this.signatureType = signatureType;
+    } else {
+      this.signatureType = getSignatureType(signer);
+      if (this.signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
+        throw new Error(
+          'Could not determine signature type from signer. Please pass a signature type to the KwilSigner constructor.'
+        );
+      }
+    }
+  }
+}

--- a/src/core/network.ts
+++ b/src/core/network.ts
@@ -1,7 +1,7 @@
 // network.ts contains interfaces for network-related data structures.
 
 export interface Account {
-    public_key: Uint8Array | string;
+    identifier: Uint8Array | string;
     balance: string;
     nonce: string;
 }

--- a/src/core/signature.ts
+++ b/src/core/signature.ts
@@ -52,8 +52,10 @@ export function isEthersSigner(signer: SignerSupplier): boolean {
 
 export async function executeSign(msg: Uint8Array , signer: SignerSupplier, signatureType: AnySignatureType): Promise<Uint8Array> {
     if(isEthersSigner(signer) && signatureType === SignatureType.SECP256K1_PERSONAL) {
-        const hexSig =  await ethSign(msg, signer as EthSigner);
-        return hexToBytes(hexSig);
+        const hexSig = await ethSign(msg, signer as EthSigner);
+        let sigBytes = hexToBytes(hexSig);
+
+        return sigBytes;
     }
 
     if(!isEthersSigner(signer) && signatureType !== SignatureType.SIGNATURE_TYPE_INVALID) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,7 @@ namespace Utils {
   /**
    * Recovers the public key from a signature and a message for Secp256k1 Public Keys (EVM Networks).
    * @param signer - The signer for the action. This must be a valid Ethereum signer from Ethers v5 or Ethers v6.
+   * @deprecated No longer supported. Ethereum accounts are now identified by their address. (will be removed in v0.5.0)
    */
   export const recoverSecp256k1PubKey = _recoverSecp256k1PubKey;
 }

--- a/src/utils/keys.ts
+++ b/src/utils/keys.ts
@@ -28,6 +28,7 @@ export function nearB58ToHex(b58: string): string {
  * @param signer - An ethereum signer from Ethers v5 or Ethers v6.
  * @param message - The message to sign. Defaults to 'Sign this message to recover your public key.'.
  * @returns A promise that resolves to the recovered public key.
+ * @deprecated No longer supported. Ethereum accounts are now identified by their address. (will be removed in v0.5.0)
  */
 
 export async function recoverSecp256k1PubKey(signer: EthSigner, message: string = 'Sign this message to recover your public key.'): Promise<string> {

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -10,6 +10,7 @@ const util = require("util")
 const near = require('near-api-js')
 const { from_b58 } = require('../dist/utils/base58')
 const { bytesToHex, hexToBytes } = require('../dist/utils/serial')
+const { bytesToBase64 } = require('../dist/utils/base64')
 const scrypt = require("scrypt-js")
 const nacl = require("tweetnacl")
 const { sha256BytesToBytes } = require("../dist/utils/crypto")
@@ -28,7 +29,8 @@ async function test() {
     const provider = new ethers.JsonRpcProvider(process.env.ETH_PROVIDER)
     const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider)
     const txHash = 'cc15becdccc22a999536aea6a3a9cddc151551bf2a44fdcbd220bc9c6f36dcdd'
-    
+    const address = await wallet.getAddress()
+
     const kwil = new kwiljs.NodeKwil({
         kwilProvider: process.env.KWIL_PROVIDER || "SHOULD FAIL",
         chainId: chainId,
@@ -39,15 +41,16 @@ async function test() {
     const pubKey = await recoverPubKey(wallet)
     const kwilSigner = new KwilSigner(wallet, pubKey)
 
+    
     const pubByte = hexToBytes(pubKey)
     const dbid = kwil.getDBID(pubByte, "mydb")
     
     // logger(dbid)
     // await authenticate(kwil, kwilSigner)
-    broadcast(kwil, testDB, wallet, pubKey)
+    broadcast(kwil, testDB, wallet, address)
     // await getTxInfo(kwil, txHash)
     // await getSchema(kwil, dbid)
-    // getAccount(kwil, pubByte)
+    // getAccount(kwil, addressBytes)
     // listDatabases(kwil, pubByte)
     // ping(kwil)
     // chainInfo(kwil)


### PR DESCRIPTION
Changed necessary logic in KwilSigner and labels in builders to reflect that Secp256k1 identifiers are now Ethereum wallet addresses rather than public keys (see more info here: https://github.com/kwilteam/kwil-db/issues/358). Marked the `recoverSecp256k1PubKey` function as deprecated, as it is no longer necessary.

BREAKING CHANGE: KwilSigners using Secp256k1 / EtherJS signers should now pass the Ethereum wallet address as the identifier, rather than the public key.