### PR TITLE
feat: make kwil.call() auto authenticate, when required

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,6 @@ const res = await kwil.call(actionBody)
         result: [ query results ],
     }
 */
-
 ```
 
 If the view action uses a `@caller` contextual variable, you should also pass the `kwilSigner` to the `kwil.call()` method. This will allow the view action to access the caller's account identifier. Note that the user does not need to sign for view actions.
@@ -349,41 +348,16 @@ const res = await kwil.deploy(deployBody, kwilSigner);
 
 ## Kwil Gateway Authentication
 
-Kwil Gateway is an optional service on Kwil networks that allows for authenticating users with their signatures for read queries. If your Kwil network used a Kwil Gateway, you can use the `kwil.authenticate()` method to authenticate users. Note the additional step of passing the cookie back to the kwil class in NodeJS.
+Kwil Gateway is an optional service on Kwil networks that allows for authenticating users with their signatures for read queries / view actions. If your Kwil network used a Kwil Gateway, you should pass a `KwilSigner` to the `kwil.call()` method. If the user is not authenticated, the user will be prompted to sign a message to authenticate, and the SDK will automatically include the authentication cookie in each subsequent request.
 
-### Web
 
-``` javascript
-// pass the kwilSigner to the authenticate method
-const res = await kwil.authenticate(kwilSigner);
-
-/*
-    res = {
-        status: 200,
-        data: {
-            result: "success"
-        }
-    }
-*/
-```
-
-### NodeJS
-
-``` javascript
-// pass the kwilSigner to the authenticate method
-const res = await kwil.authenticate(kwilSigner);
+```javascript
+// pass KwilSigner to the call method
+const res = await kwil.call(actionBody, kwilSigner);
 
 /*
-    res = {
-        status: 200,
-        data: {
-            result: "success",
-            cookie: "some_cookie"
-        },
-        
+    res.data = {
+        result: [ query results ],
     }
 */
-
-// pass the cookie to the kwil class
-kwil.setCookie(res.data.cookie)
 ```

--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -240,7 +240,11 @@ export default class Client extends Api {
     };
 
     const res = await super.post<CallRes>(`/api/v1/call`, req);
-    checkRes(res);
+
+    // if we get a 401, we need to return the response so we can try to authenticate
+    if(res.status !== 401) {
+      checkRes(res);
+    }
 
     let result: any = null;
 

--- a/src/client/node/nodeKwil.ts
+++ b/src/client/node/nodeKwil.ts
@@ -1,8 +1,10 @@
 import Client from '../../api_client/client';
 import { Config } from '../../api_client/config';
-import { AuthSuccess } from '../../core/auth';
+import { ActionBuilderImpl } from '../../builders/action_builder';
+import { ActionBody, ActionInput, Entries } from '../../core/action';
 import { EnvironmentType } from '../../core/enums';
 import { KwilSigner } from '../../core/kwilSigner';
+import { BaseMessage, Message, MsgReceipt } from '../../core/message';
 import { GenericResponse } from '../../core/resreq';
 import { Kwil } from '../kwil';
 
@@ -13,12 +15,71 @@ export class NodeKwil extends Kwil<EnvironmentType.NODE> {
     super(opts);
     this.config = opts;
   }
+  /**
+   * Calls a Kwil node. This can be used to execute read-only ('view') actions on Kwil.
+   * If the action requires authentication in the Kwil Gateway, the kwilSigner should be passed. If the user is not authenticated, the user will be prompted to authenticate.
+   *
+   * @param actionBody - The body of the action to send. This should use the `ActionBody` interface.
+   * @param kwilSigner (optional) - Caller should be passed if the action requires authentication OR if the action uses a `@caller` contextual variable. If `@caller` is used and authentication is not required, the user will not be prompted to authenticate; however, the user's identifier will be passed as the sender.
+   * @returns A promise that resolves to the receipt of the message.
+   */
+  public async call(
+    actionBody: ActionBody,
+    kwilSigner?: KwilSigner
+  ): Promise<GenericResponse<MsgReceipt>>;
 
-  public async authenticate(signer: KwilSigner): Promise<GenericResponse<AuthSuccess<EnvironmentType.NODE>>> {
-    return await super.authenticate(signer);
-  }
+  /**
+   * Calls a Kwil node. This can be used to execute read-only ('view') actions on Kwil.
+   *
+   * @param actionBody - The message to send. The message can be built using the ActionBuilder class.
+   * @returns A promise that resolves to the receipt of the message.
+   */
+  public async call(actionBody: Message): Promise<GenericResponse<MsgReceipt>>;
 
-  public setCookie(cookie: string): void {
-    this.client = new Client(this.config, cookie);
+  public async call(
+    actionBody: Message | ActionBody,
+    kwilSigner?: KwilSigner
+  ): Promise<GenericResponse<MsgReceipt>> {
+    if (actionBody instanceof BaseMessage) {
+      return await this.client.call(actionBody);
+    }
+
+    let msg = ActionBuilderImpl.of<EnvironmentType.NODE>(this)
+      .chainId(this.chainId)
+      .dbid(actionBody.dbid)
+      .name(actionBody.action)
+      .description(actionBody.description || '');
+
+    if (actionBody.inputs) {
+      const inputs =
+        actionBody.inputs[0] instanceof ActionInput
+          ? (actionBody.inputs as ActionInput[])
+          : new ActionInput().putFromObjects(actionBody.inputs as Entries[]);
+      msg = msg.concat(inputs);
+    }
+
+    if (kwilSigner) {
+      msg = msg
+        .signer(kwilSigner.signer, kwilSigner.signatureType)
+        .publicKey(kwilSigner.identifier);
+    }
+
+    const message = await msg.buildMsg();
+
+    let res = await this.client.call(message);
+
+    if(res.status === 401) {
+      if (kwilSigner) {
+        const authRes = await this.authenticate(kwilSigner);
+        if(authRes.status === 200) {
+          this.client = new Client(this.config, authRes.data?.cookie);
+          res = await this.client.call(message);
+        }
+      } else {
+        throw new Error('Action requires authentication. Pass a KwilSigner to authenticate.')
+      }
+    }
+
+    return res;
   }
 }

--- a/src/client/web/webKwil.ts
+++ b/src/client/web/webKwil.ts
@@ -1,7 +1,10 @@
 import { Config } from '../../api_client/config';
+import { ActionBuilderImpl } from '../../builders/action_builder';
+import { ActionBody, ActionInput, Entries } from '../../core/action';
 import { AuthSuccess } from '../../core/auth';
 import { EnvironmentType } from '../../core/enums';
 import { KwilSigner } from '../../core/kwilSigner';
+import { BaseMessage, Message, MsgReceipt } from '../../core/message';
 import { GenericResponse } from '../../core/resreq';
 import { Kwil } from '../kwil';
 
@@ -10,7 +13,70 @@ export class WebKwil extends Kwil<EnvironmentType.BROWSER> {
     super(opts);
   }
 
-  async authenticate(signer: KwilSigner): Promise<GenericResponse<AuthSuccess<EnvironmentType.BROWSER>>> {
-    return super.authenticate(signer);
+  /**
+   * Calls a Kwil node. This can be used to execute read-only ('view') actions on Kwil.
+   * If the action requires authentication in the Kwil Gateway, the kwilSigner should be passed. If the user is not authenticated, the user will be prompted to authenticate.
+   *
+   * @param {ActionBody} actionBody - The body of the action to send. This should use the `ActionBody` interface.
+   * @param {KwilSigner} kwilSigner (optional) - Caller should be passed if the action requires authentication OR if the action uses a `@caller` contextual variable. If `@caller` is used and authentication is not required, the user will not be prompted to authenticate; however, the user's identifier will be passed as the sender.
+   * @returns A promise that resolves to the receipt of the message.
+   */
+  public async call(
+    actionBody: ActionBody,
+    kwilSigner?: KwilSigner
+  ): Promise<GenericResponse<MsgReceipt>>;
+
+  /**
+   * Calls a Kwil node. This can be used to execute read-only ('view') actions on Kwil.
+   *
+   * @param actionBody - The message to send. The message can be built using the ActionBuilder class.
+   * @returns A promise that resolves to the receipt of the message.
+   */
+  public async call(actionBody: Message): Promise<GenericResponse<MsgReceipt>>;
+
+  public async call(
+    actionBody: Message | ActionBody,
+    kwilSigner?: KwilSigner
+  ): Promise<GenericResponse<MsgReceipt>> {
+    if (actionBody instanceof BaseMessage) {
+      return await this.client.call(actionBody);
+    }
+
+    let msg = ActionBuilderImpl.of<EnvironmentType.BROWSER>(this)
+      .chainId(this.chainId)
+      .dbid(actionBody.dbid)
+      .name(actionBody.action)
+      .description(actionBody.description || '');
+
+    if (actionBody.inputs) {
+      const inputs =
+        actionBody.inputs[0] instanceof ActionInput
+          ? (actionBody.inputs as ActionInput[])
+          : new ActionInput().putFromObjects(actionBody.inputs as Entries[]);
+      msg = msg.concat(inputs);
+    }
+
+    if (kwilSigner) {
+      msg = msg
+        .signer(kwilSigner.signer, kwilSigner.signatureType)
+        .publicKey(kwilSigner.identifier);
+    }
+
+    const message = await msg.buildMsg();
+
+    let res = await this.client.call(message);
+
+    if(res.status === 401) {
+      if (kwilSigner) {
+        const authRes = await this.authenticate(kwilSigner);
+        if(authRes.status === 200) {
+          res = await this.client.call(message);
+        }
+      } else {
+        throw new Error('Action requires authentication. Pass a KwilSigner to authenticate.')
+      }
+    }
+
+    return res;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ namespace Utils {
   /**
    * Recovers the public key from a signature and a message for Secp256k1 Public Keys (EVM Networks).
    * @param signer - The signer for the action. This must be a valid Ethereum signer from Ethers v5 or Ethers v6.
-   * @deprecated No longer supported. Ethereum accounts are now identified by their address. (will be removed in kwil-js v0.5.0)
+   * @deprecated No longer supported. Ethereum accounts are now identified by their address. (will be removed in kwil-js v0.6.0)
    */
   export const recoverSecp256k1PubKey = _recoverSecp256k1PubKey;
 }

--- a/src/utils/keys.ts
+++ b/src/utils/keys.ts
@@ -28,7 +28,7 @@ export function nearB58ToHex(b58: string): string {
  * @param signer - An ethereum signer from Ethers v5 or Ethers v6.
  * @param message - The message to sign. Defaults to 'Sign this message to recover your public key.'.
  * @returns A promise that resolves to the recovered public key.
- * @deprecated No longer supported. Ethereum accounts are now identified by their address. (will be removed in v0.5.0)
+ * @deprecated No longer supported. Ethereum accounts are now identified by their address. (will be removed in v0.6.0)
  */
 
 export async function recoverSecp256k1PubKey(signer: EthSigner, message: string = 'Sign this message to recover your public key.'): Promise<string> {

--- a/testing-functions/mydb.json
+++ b/testing-functions/mydb.json
@@ -118,9 +118,7 @@
       "inputs": null,
       "public": true,
       "mutability": "view",
-      "auxiliaries": [
-        "mustsign"
-      ],
+      "auxiliaries": null,
       "statements": [
         "SELECT * from posts;"
       ]

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -28,7 +28,7 @@ async function test() {
     //update to goerli when live
     const provider = new ethers.JsonRpcProvider(process.env.ETH_PROVIDER)
     const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider)
-    const txHash = 'fb07af19fdf04d3693216ad9d9699d9f4a72f387882ebd3ef82e69dbfed219ea'
+    const txHash = 'c0b758cf6385b19549ee522acd5d662d5db1974d3e8269d5e6870374f8d32bff'
     const address = await wallet.address
 
     const getEdKeys = async () => {
@@ -48,9 +48,9 @@ async function test() {
     
     const pubByte = hexToBytes(pubKey)
     const dbid = kwil.getDBID(address, "mydb")
-    // logger(dbid)
+    logger(dbid)
     // await authenticate(kwil, kwilSigner)
-    broadcast(kwil, testDB, wallet, address)
+    // broadcast(kwil, testDB, wallet, address)
     // broadcastEd25519(kwil, simpleDb)
     // await getTxInfo(kwil, txHash)
     // await getSchema(kwil, dbid)
@@ -63,7 +63,7 @@ async function test() {
     // await select(kwil, dbid, "SELECT * FROM posts")
     // bulkAction(kwil, dbid, "add_post", wallet, address)
     // await testViewWithParam(kwil, dbid, wallet)
-    // await testViewWithSign(kwil, dbid, wallet, pubByte)
+    // await testViewWithSign(kwil, dbid, kwilSigner)
     // await testViewWithEdSigner(kwil, dbid)
     // await customSignature(kwil, dbid)
     // await julioSignature(kwil, dbid)
@@ -277,20 +277,16 @@ async function testViewWithParam(kwil, dbid, wallet) {
     logger(res.data.result)
 }
 
-async function testViewWithSign(kwil, dbid, wallet, pubKey) {
-    const msg = await kwil
-        .actionBuilder()
-        .dbid(dbid)
-        .name('view_must_sign')
-        .publicKey(pubKey)
-        .description('This is my friendly description!')
-        .signer(wallet)
-        .buildMsg()
+async function testViewWithSign(kwil, dbid, signer) {
+    const body = {
+        action: "view_must_sign",
+        dbid,
+        inputs: []
+    }
 
-    logger(msg)
-    const res = await kwil.call(msg);
+    const res = await kwil.call(body, signer)
 
-    logger(res.data.result)
+    logger(res)
 }
 
 async function testViewWithEdSigner(kwil, dbid) {

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -63,7 +63,7 @@ async function test() {
     // await select(kwil, dbid, "SELECT * FROM posts")
     // bulkAction(kwil, dbid, "add_post", wallet, address)
     // await testViewWithParam(kwil, dbid, wallet)
-    // await testViewWithSign(kwil, dbid, kwilSigner)
+    await testViewWithSign(kwil, dbid, kwilSigner)
     // await testViewWithEdSigner(kwil, dbid)
     // await customSignature(kwil, dbid)
     // await julioSignature(kwil, dbid)

--- a/testing-functions/ts_test.ts
+++ b/testing-functions/ts_test.ts
@@ -9,6 +9,7 @@ require('dotenv').config()
 const kwil = new NodeKwil({
     kwilProvider: process.env.KWIL_PROVIDER as string,
     chainId: process.env.CHAIN_ID as string,
+    logging: true,
 })
 
 const provider = new JsonRpcProvider(process.env.ETH_PROVIDER)
@@ -23,8 +24,8 @@ async function main() {
 
     // actions
     const actionBody: ActionBody = {
-        dbid: 'xd924382720df474c6bb62d26da9aeb10add2ad2835c0b7e4a6336ad8',
-        action: 'add_post',
+        dbid: kwil.getDBID(signer.identifier, 'mydb'),
+        action: 'view_must_sign',
         inputs: [{
             "$id": 69,
             "$user": "Luke",
@@ -38,7 +39,8 @@ async function main() {
     // await kwil.execute(actionBody, signer);
 
     //call with signer
-    // await kwil.call(actionBody, signer);
+    const callRes = await kwil.call(actionBody, signer);
+    console.log(callRes);
 
     //call without signer
     // await kwil.call(actionBody);
@@ -67,8 +69,8 @@ async function main() {
     }
 
     // transfer
-    const res = await kwil.funder.transfer(funderTest, signer);
-    console.log(res);
+    // const res = await kwil.funder.transfer(funderTest, signer);
+    // console.log(res);
 }
 
 main()

--- a/tests/testingUtils.ts
+++ b/tests/testingUtils.ts
@@ -101,9 +101,3 @@ export const deriveKeyPair64 = async (password: string, humanId: string) => {
 
     return nacl.sign.keyPair.fromSeed(derivedKey);
 };
-
-export async function setAuth(kwil: NodeKwil, signer: KwilSigner): Promise<void> {
-    const auth = await kwil.authenticate(signer);
-    const cookie = objects.requireNonNil(auth.data?.cookie);
-    kwil.setCookie(cookie);
-}


### PR DESCRIPTION
When using Kwil Gateway (kgw) for authentication, the `.call()` method will automatically try to authenticate if it receives a 401 error. This removes the need for the `.authenticate()` and `.setCookie()` methods.

BREAKING CHANGE: Remove the `kwil.authenticate()` and `kwil.setCookie()` methods, as those methods are now handled internally by the `kwil.call()` method.