### PR TITLE
fix(rlp): fix bug where boolean false was not rlp encoded correctly

### DIFF
--- a/src/builders/db_builder.ts
+++ b/src/builders/db_builder.ts
@@ -361,7 +361,7 @@ export class DBBuilderImpl<T extends DeployOrDrop, U extends EnvironmentType> im
           action.auxiliaries = [];
         }
 
-        if (!action.public) {
+        if ((action.public === undefined )|| (action.public === null)) {
           action.public = true;
         }
 

--- a/src/utils/rlp.ts
+++ b/src/utils/rlp.ts
@@ -33,7 +33,7 @@ function inputToHex(val: string | number | BigInt | Uint8Array | Boolean | null 
     } else if (val instanceof Uint8Array) {
         return bytesToEthHex(val);
     } else if (typeof val === 'boolean') {
-        return val ? "0x01" : "0x00";
+        return val ? "0x01" : "0x";
     } else if (val === null || val === undefined) {
         return bytesToEthHex(new Uint8Array(0));
     } else {


### PR DESCRIPTION
This commit fixes two bugs: (1) when passing a schema with public set to false, it was overriding the property to true in the DbBuilder's `makePayloadEncodable` method. Rather than checking if the property is falsy, it should just check if it is null or undefined. (2) Previously, `false` was hexlified to `0x00` before RLP encoding, but the proper false hex encoding for RLP is `0x`.