### PR TITLE
fix: rlp encoding zero and case sensitivity for action input names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
-  "name": "@lukelamey/kwil-js",
+  "name": "@kwilteam/kwil-js",
   "version": "0.5.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "@lukelamey/kwil-js",
+      "name": "@kwilteam/kwil-js",
       "version": "0.5.2",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",
         "dotenv": "^16.0.3",
-        "ethers": "^6.8.1",
+        "ethers": "^6.9.1",
         "ethers5": "npm:ethers@^5.7.2",
         "jssha": "^3.2.0",
         "long": "^5.2.1"
@@ -5079,9 +5079,9 @@
       }
     },
     "node_modules/ethers": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.8.1.tgz",
-      "integrity": "sha512-iEKm6zox5h1lDn6scuRWdIdFJUCGg3+/aQWu0F4K0GVyEZiktFkqrJbRjTn1FlYEPz7RKA707D6g5Kdk6j7Ljg==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.9.1.tgz",
+      "integrity": "sha512-kuV8fGd4/8Gj7wkurbsuUsm1DCG6N5gKGYdw3fnWG/7QGknhy1xtHD7kbkCWQAcbAYmzLCLqCPedS3FYncFkKQ==",
       "funding": [
         {
           "type": "individual",
@@ -13299,9 +13299,9 @@
       "dev": true
     },
     "ethers": {
-      "version": "6.8.1",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.8.1.tgz",
-      "integrity": "sha512-iEKm6zox5h1lDn6scuRWdIdFJUCGg3+/aQWu0F4K0GVyEZiktFkqrJbRjTn1FlYEPz7RKA707D6g5Kdk6j7Ljg==",
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.9.1.tgz",
+      "integrity": "sha512-kuV8fGd4/8Gj7wkurbsuUsm1DCG6N5gKGYdw3fnWG/7QGknhy1xtHD7kbkCWQAcbAYmzLCLqCPedS3FYncFkKQ==",
       "requires": {
         "@adraffy/ens-normalize": "1.10.0",
         "@noble/curves": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
   "dependencies": {
     "axios": "^0.27.2",
     "dotenv": "^16.0.3",
-    "ethers": "^6.8.1",
+    "ethers": "^6.9.1",
     "ethers5": "npm:ethers@^5.7.2",
     "jssha": "^3.2.0",
     "long": "^5.2.1"

--- a/src/builders/action_builder.ts
+++ b/src/builders/action_builder.ts
@@ -503,7 +503,9 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
         preparedActions.push(
           actionSchema.inputs.map((i) => {
             const val = copy.get(i);
-            if (val) {
+
+            // because all values are technically strings under the kwildb hood, we need to convert all values that will resolve to a string to a string.
+            if (val?.toString()) {
               return val.toString();
             }
             return val;

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -60,6 +60,7 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public put<T extends ValueType>(key: string, value: T): ActionInput {
+    key = lowercaseKey(key);
     this.map[assertKey(key)] = value;
     return this;
   }
@@ -72,6 +73,7 @@ export class ActionInput implements Iterable<EntryType> {
    * @returns The current `ActionInput` instance for chaining.
    */
   public putIfAbsent<T extends ValueType>(key: string, value: T): ActionInput {
+    key = lowercaseKey(key);
     if (!this.containsKey(key)) {
       this.map[key] = value;
     }
@@ -87,6 +89,7 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public replace<T extends ValueType>(key: string, value: T): ActionInput {
+    key = lowercaseKey(key);
     if (this.containsKey(key)) {
       this.map[key] = value;
     }
@@ -101,6 +104,7 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public get<T extends ValueType>(key: string): T {
+    key = lowercaseKey(key);
     return this.map[assertKey(key)] as T;
   }
 
@@ -113,6 +117,7 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public getOrDefault<T extends ValueType>(key: string, defaultValue: T): T {
+    key = lowercaseKey(key);
     return (this.map[assertKey(key)] ?? defaultValue) as T;
   }
 
@@ -124,6 +129,7 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public containsKey(key: string): boolean {
+    key = lowercaseKey(key);
     return this.map.hasOwnProperty(assertKey(key));
   }
 
@@ -135,6 +141,7 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public remove(key: string): boolean {
+    key = lowercaseKey(key);
     return delete this.map[key];
   }
 
@@ -177,7 +184,8 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public putFromObject<T extends {}>(obj: T): ActionInput {
-    for (const [key, value] of Object.entries(objects.requireNonNil(obj))) {
+    for (let [key, value] of Object.entries(objects.requireNonNil(obj))) {
+      key = lowercaseKey(key);
       this.map[assertKey(key)] = value as ValueType;
     }
     return this;
@@ -191,7 +199,8 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public putFromObjectIfAbsent<T extends {}>(obj: T): ActionInput {
-    for (const [key, value] of Object.entries(objects.requireNonNil(obj))) {
+    for (let [key, value] of Object.entries(objects.requireNonNil(obj))) {
+      key = lowercaseKey(key);
       if (!this.containsKey(key)) {
         this.map[assertKey(key)] = value as ValueType;
       }
@@ -207,7 +216,8 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public replaceFromObject<T extends {}>(obj: T): ActionInput {
-    for (const [key, value] of Object.entries(objects.requireNonNil(obj))) {
+    for (let [key, value] of Object.entries(objects.requireNonNil(obj))) {
+      key = lowercaseKey(key);
       if (this.containsKey(key)) {
         this.map[assertKey(key)] = value as ValueType;
       }
@@ -249,7 +259,8 @@ export class ActionInput implements Iterable<EntryType> {
 
   public static from(entries: Iterable<EntryType>): ActionInput {
     const action = ActionInput.of();
-    for (const [key, value] of objects.requireNonNil(entries)) {
+    for (let [key, value] of objects.requireNonNil(entries)) {
+      key = lowercaseKey(key);
       action.map[assertKey(key)] = value;
     }
     return action;
@@ -264,7 +275,8 @@ export class ActionInput implements Iterable<EntryType> {
 
   public static fromObject<T extends {}>(obj: T): ActionInput {
     const action = ActionInput.of();
-    for (const [key, value] of Object.entries(objects.requireNonNil(obj))) {
+    for (let [key, value] of Object.entries(objects.requireNonNil(obj))) {
+      key = lowercaseKey(key);
       action.map[assertKey(key)] = value as ValueType;
     }
     return action;
@@ -296,4 +308,8 @@ export class ActionInput implements Iterable<EntryType> {
 
 function assertKey(key: string): string {
   return objects.requireNonNil(key, 'key cannot be nil');
+}
+
+function lowercaseKey(key: string): string {
+  return key.toLowerCase();
 }

--- a/test-eth-app/package-lock.json
+++ b/test-eth-app/package-lock.json
@@ -8,6 +8,7 @@
       "name": "testapp",
       "version": "0.0.0",
       "dependencies": {
+        "@kwilteam/kwil-js": "^0.5.2",
         "@lukelamey/kwil-js": "^0.3.11",
         "ethers": "^6.8.1",
         "ethers5": "npm:ethers@^5.7.2",
@@ -1646,6 +1647,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kwilteam/kwil-js": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@kwilteam/kwil-js/-/kwil-js-0.5.2.tgz",
+      "integrity": "sha512-LYhHVBOpmoofidLkbwIi9rJrg00O90pOnUZ1SMoi5PbflPgJemwf+4IfrZcqRNhSctleLC5aUXqsICMkE4uWgg==",
+      "dependencies": {
+        "axios": "^0.27.2",
+        "dotenv": "^16.0.3",
+        "ethers": "^6.8.1",
+        "ethers5": "npm:ethers@^5.7.2",
+        "jssha": "^3.2.0",
+        "long": "^5.2.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@lukelamey/kwil-js": {
@@ -5881,6 +5898,19 @@
       "requires": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "@kwilteam/kwil-js": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@kwilteam/kwil-js/-/kwil-js-0.5.2.tgz",
+      "integrity": "sha512-LYhHVBOpmoofidLkbwIi9rJrg00O90pOnUZ1SMoi5PbflPgJemwf+4IfrZcqRNhSctleLC5aUXqsICMkE4uWgg==",
+      "requires": {
+        "axios": "^0.27.2",
+        "dotenv": "^16.0.3",
+        "ethers": "^6.8.1",
+        "ethers5": "npm:ethers@^5.7.2",
+        "jssha": "^3.2.0",
+        "long": "^5.2.1"
       }
     },
     "@lukelamey/kwil-js": {

--- a/test-eth-app/package.json
+++ b/test-eth-app/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@kwilteam/kwil-js": "^0.5.2",
     "@lukelamey/kwil-js": "^0.3.11",
     "ethers": "^6.8.1",
     "ethers5": "npm:ethers@^5.7.2",

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -28,7 +28,7 @@ async function test() {
     //update to goerli when live
     const provider = new ethers.JsonRpcProvider(process.env.ETH_PROVIDER)
     const wallet = new ethers.Wallet(process.env.PRIVATE_KEY, provider)
-    const txHash = '04677335c200633fef0ba65de24609450124a2bc5ca2451245ffb00efccb54c8'
+    const txHash = 'b1ac84b20a99b7ad42435d653e4ed21c4cfa86c88b929e385f33664314ab5bec'
     const address = await wallet.address
 
     const getEdKeys = async () => {
@@ -47,12 +47,12 @@ async function test() {
     const kwilSigner = new KwilSigner(wallet, address)
     
     const pubByte = hexToBytes(pubKey)
-    const dbid = kwil.getDBID(address, "mydb")
+    const dbid = kwil.getDBID(address, "fractal_marketplace")
     logger(dbid)
     // await authenticate(kwil, kwilSigner)
-    broadcast(kwil, testDB, wallet, address)
+    // broadcast(kwil, testDB, wallet, address)
     // broadcastEd25519(kwil, simpleDb)
-    // await getTxInfo(kwil, txHash)
+    await getTxInfo(kwil, txHash)
     // await getSchema(kwil, dbid)
     // getAccount(kwil, address)
     // listDatabases(kwil)

--- a/testing-functions/ts_test.ts
+++ b/testing-functions/ts_test.ts
@@ -1,76 +1,85 @@
-import { Wallet, JsonRpcProvider } from "ethers";
-import { KwilSigner, NodeKwil, Utils } from "../dist/index";
-import { ActionBody } from "../dist/core/action";
-import { DeployBody, DropBody } from "../dist/core/database";
-import compiledKf from "./math.kf.json";
-import { TransferBody } from "../dist/funder/funding_types";
-require('dotenv').config()
+import { BrowserProvider, Wallet } from 'ethers';
+import { KwilSigner, NodeKwil, Utils } from '../dist/index';
+import { ActionBody } from '../dist/core/action';
+import { DeployBody, DropBody } from '../dist/core/database';
+import compiledKf from './math.kf.json';
+import { TransferBody } from '../dist/funder/funding_types';
+require('dotenv').config();
 
 const kwil = new NodeKwil({
-    kwilProvider: process.env.KWIL_PROVIDER as string,
-    chainId: process.env.CHAIN_ID as string,
-    logging: true,
-})
+  kwilProvider: process.env.KWIL_PROVIDER as string,
+  chainId: process.env.CHAIN_ID as string,
+  logging: true,
+});
 
-const provider = new JsonRpcProvider(process.env.ETH_PROVIDER)
-const wallet = new Wallet(process.env.PRIVATE_KEY as string, provider)
+import { JsonRpcProvider } from 'ethers';
+
+// add window.ethereum to typeof globalthis
+declare global {
+  interface Window {
+    ethereum: any;
+  }
+} 
 
 async function buildSigner() {
+    const wallet = new Wallet(process.env.PRIVATE_KEY as string)
     return new KwilSigner(wallet, await wallet.getAddress());
 }
 
 async function main() {
-    const signer = await buildSigner();
+  const signer = await buildSigner();
 
-    // actions
-    const actionBody: ActionBody = {
-        dbid: kwil.getDBID(signer.identifier, 'mydb'),
-        action: 'view_must_sign',
-        inputs: [{
-            "$id": 69,
-            "$user": "Luke",
-            "$title": "Test Post",
-            "$body": "This is a test post"
-        }],
-        description: "Add a post"
-    }
+  // actions
+  const actionBody: ActionBody = {
+    dbid: kwil.getDBID(signer.identifier, 'mydb'),
+    action: 'add_post',
+    inputs: [
+      {
+        $id: 69,
+        $user: 'Luke',
+        $title: 'Test Post',
+        $body: 'This is a test post',
+      },
+    ],
+    description: 'Add a post',
+  };
 
-    // execute
-    // await kwil.execute(actionBody, signer);
+  // execute
+  await kwil.execute(actionBody, signer);
 
-    //call with signer
-    const callRes = await kwil.call(actionBody, signer);
-    console.log(callRes);
+  //call with signer
+  const callRes = await kwil.call(actionBody, signer);
+  console.log(callRes);
 
-    //call without signer
-    // await kwil.call(actionBody);
+  //call without signer
+  // await kwil.call(actionBody);
 
-    // deploy database
-    const deployBody: DeployBody = {
-        schema: compiledKf,
-        description: "My first database"
-    }
+  // deploy database
+  const deployBody: DeployBody = {
+    schema: compiledKf,
+    description: 'My first database',
+  };
 
-    // deploy
-    // await kwil.deploy(deployBody, signer);
-    
-    // drop database
-    const dropBody: DropBody = {
-        dbid: 'abc123',
-        description: "Drop this database"
-    }
+  // deploy
+  // await kwil.deploy(deployBody, signer);
 
-    // drop
-    // await kwil.drop(dropBody, signer);
+  // drop database
+  const dropBody: DropBody = {
+    dbid: 'abc123',
+    description: 'Drop this database',
+  };
 
-    const funderTest: TransferBody = {
-        to: "0xdB8C53Cd9be615934da491A7476f3f3288d98fEb",
-        amount: BigInt(1 * 10 ** 18),
-    }
+  // drop
+  // await kwil.drop(dropBody, signer);
 
-    // transfer
-    // const res = await kwil.funder.transfer(funderTest, signer);
-    // console.log(res);
+  const funderTest: TransferBody = {
+    to: '0xdB8C53Cd9be615934da491A7476f3f3288d98fEb',
+    amount: BigInt(1 * 10 ** 18),
+  };
+
+  // transfer
+  // const res = await kwil.funder.transfer(funderTest, signer);
+  // console.log(res);
 }
 
-main()
+main();

--- a/tests/kwil.test.ts
+++ b/tests/kwil.test.ts
@@ -116,7 +116,7 @@ describe('Kwil', () => {
 (isGasOn ? describe : describe.skip)('Testing Kwil.funder', () => {
   const funder = kwil.funder;
 
-  it.only('should transfer tokens', async () => {
+  it('should transfer tokens', async () => {
     const transferBody = {
       to: '0x6E2fA2aF9B4eF5c8A3BcF9A9B9A4F1a1a2c1c1c1',
       amount: BigInt(1),


### PR DESCRIPTION
This commit fixes two bugs in kwil-js. First, handles how we RLP encode zero. Because kwil-db stores all values as strings under the hood, we need to be RLP encoding the integer zero as a string. The reason we only hit this bug on the number zero is that previously, the SDK coverted all truthy values to a string, which missed converting zero to string, thereby sending zero to be rlp encoded as an integer. This commit changes the stringify logic for all values that return with .toString(), so zero does not get missed. Second, actionInput keys were not case insensitive, which led some users to get unexpected errors when typing an action name as case sensitive. This commit forces all actioninput keys to be lowercase.