### PR TITLE
feat: add sync flag to transactions

### DIFF
--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -26,7 +26,7 @@ import { base64UrlEncode, bytesToHex, hexToBytes } from '../utils/serial';
 import { TxInfoReceipt } from '../core/txQuery';
 import { Message, MsgData, MsgReceipt } from '../core/message';
 import { kwilDecode } from '../utils/rlp';
-import { BytesEncodingStatus, EnvironmentType } from '../core/enums';
+import { BroadcastSyncType, BytesEncodingStatus, EnvironmentType } from '../core/enums';
 import { AuthInfo, AuthSuccess, AuthenticatedBody } from '../core/auth';
 import { AxiosResponse } from 'axios';
 
@@ -157,12 +157,16 @@ export default class Client extends Api {
     return checkRes(res, (r) => r.price);
   }
 
-  public async broadcast(tx: Transaction): Promise<GenericResponse<TxReceipt>> {
+  public async broadcast(tx: Transaction, broadcastSync?: BroadcastSyncType): Promise<GenericResponse<TxReceipt>> {
     if (!tx.isSigned()) {
       throw new Error('Tx must be signed before broadcasting.');
     }
 
-    let req: BroadcastReq = { tx: tx.txData };
+    const req: BroadcastReq = { 
+      tx: tx.txData,
+      ...(broadcastSync !== (null || undefined) ? { sync: broadcastSync } : {}),
+    };
+
     const res = await super.post<BroadcastRes>(`/api/v1/broadcast`, req);
     checkRes(res);
 

--- a/src/core/enums.ts
+++ b/src/core/enums.ts
@@ -59,3 +59,9 @@ export enum EnvironmentType {
 }
 
 export type PayloadBytesTypes = BytesEncodingStatus.BASE64_ENCODED | BytesEncodingStatus.UINT8_ENCODED;
+
+export enum BroadcastSyncType {
+    ASYNC = 0,
+    SYNC = 1,
+    COMMIT = 2
+}

--- a/src/core/resreq.ts
+++ b/src/core/resreq.ts
@@ -2,7 +2,7 @@ import { Database } from './database';
 import { Account, ChainInfo, DatasetInfoServer } from './network';
 import { BaseTransaction, TxReceipt, TxnData } from './tx';
 import { TxResult } from './txQuery';
-import { BytesEncodingStatus, EnvironmentType } from './enums';
+import { BroadcastSyncType, BytesEncodingStatus, EnvironmentType } from './enums';
 import { AuthInfo } from './auth';
 
 type SchemaRes = Database & {
@@ -36,6 +36,7 @@ export interface EstimateCostRes {
 
 export interface BroadcastReq {
   tx: TxnData<BytesEncodingStatus.BASE64_ENCODED>;
+  sync?: BroadcastSyncType;
 }
 
 export interface BroadcastRes extends TxReceipt {}

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -47,12 +47,12 @@ async function test() {
     const kwilSigner = new KwilSigner(wallet, address)
     
     const pubByte = hexToBytes(pubKey)
-    const dbid = kwil.getDBID(address, "fractal_marketplace")
+    const dbid = kwil.getDBID(address, "mydb")
     logger(dbid)
     // await authenticate(kwil, kwilSigner)
     // broadcast(kwil, testDB, wallet, address)
     // broadcastEd25519(kwil, simpleDb)
-    await getTxInfo(kwil, txHash)
+    // await getTxInfo(kwil, txHash)
     // await getSchema(kwil, dbid)
     // getAccount(kwil, address)
     // listDatabases(kwil)
@@ -69,6 +69,7 @@ async function test() {
     // await julioSignature(kwil, dbid)
     // await customEd25519(kwil, dbid)
     // await dropDb(kwil, dbid, wallet, address)
+    // await transfer(kwil, "0xAfFDC06cF34aFD7D5801A13d48C92AD39609901D", 100, kwilSigner)
 }
 
 test()
@@ -138,7 +139,7 @@ async function execSingleAction(kwil, dbid, action, w, pubKey) {
     const Input = kwiljs.Utils.ActionInput
 
     const solo = Input.of()
-        .put("$id", count + 1)
+        .put("$id", count)
         .put("$user", "Luke")
         .put("$title", "Hello") 
         .put("$body", "Hello World")
@@ -153,14 +154,15 @@ async function execSingleAction(kwil, dbid, action, w, pubKey) {
         .signer(w)
         .buildTx();
 
-    const res = await kwil.broadcast(act)
+    const startTime = Date.now()
+
+    const res = await kwil.broadcast(act, 2)
 
     logger(res)
 }
 
 async function execSingleActionKwilSigner(kwil, dbid, action, kSigner) {
     const query = await kwil.selectQuery(dbid, "SELECT COUNT(*) FROM posts");
-
     const count = query.data[0][`COUNT(*)`]
 
     const Input = kwiljs.Utils.ActionInput
@@ -177,7 +179,10 @@ async function execSingleActionKwilSigner(kwil, dbid, action, kSigner) {
         description: 'This is my friendly description!',
     }
 
-    const res = await kwil.execute(body, kSigner)
+    const startTime = Date.now()
+    const res = await kwil.execute(body, kSigner, true)
+    const endTime = Date.now()
+    console.log(`Time: ${endTime - startTime}ms`)
 
     logger(res)
 }
@@ -439,4 +444,14 @@ async function auth(kwil, signer, ident, type) {
     }
 
     kwil.setCookie(cookie)
+}
+
+async function transfer(kwil, to, tokenAmnt, signer) {
+    const payload = {
+        to,
+        amount: BigInt(tokenAmnt * 10 ** 18)
+    }
+
+    const res = await kwil.funder.transfer(payload, signer)
+    logger(res)
 }


### PR DESCRIPTION
Added an optional `sync` argument to `kwil.execute()`, `kwil.deploy()`, `kwil.drop()`, and `kwil.funder.transfer()`. This optional argument will wait for the chain to confirm the transaction before returning.

close #62