### PR TITLE
fix(payload_builder.ts): set fee to 0 when estimating cost

### DIFF
--- a/src/builders/payload_builder.ts
+++ b/src/builders/payload_builder.ts
@@ -219,6 +219,8 @@ export class PayloadBuilderImpl<T extends EnvironmentType> implements PayloadBui
       // rlp encode the payload and convert to base64
       tx.body.payload = bytesToBase64(kwilEncode(resolvedPayload));
       tx.body.payload_type = payloadType;
+      // set the fee to 0 for estimating cost
+      tx.body.fee = "0"
     });
 
     // estimate the cost of the transaction with the estimateCost symbol from the client


### PR DESCRIPTION
Addressed minor change in kwil-db that requires a non-null value for the fee when sending the TxBody to any proto requests. See
https://github.com/kwilteam/kwil-db/commit/fa0ceaea5cd8141d643fac66bc7f8f9e3754d7b1#diff-29b727c2a7cdca0ced9103a0a61a8e9bfde5911470a028b553e77d7e1d05b7d7