### PR TITLE
fix: remove variadic args from CustomSigner

### DIFF
--- a/src/core/builders.ts
+++ b/src/core/builders.ts
@@ -11,7 +11,7 @@ export type EthSigner = {
   signMessage: (message: string | Uint8Array) => Promise<string>;
 };
 
-export type CustomSigner = NonNil<(message: Uint8Array, ...args: any[]) => Promise<Uint8Array>>;
+export type CustomSigner = NonNil<(message: Uint8Array) => Promise<Uint8Array>>;
 export type SignerSupplier = Promisy<EthSigner | CustomSigner>;
 
 /**

--- a/src/core/kwilSigner.ts
+++ b/src/core/kwilSigner.ts
@@ -50,16 +50,25 @@ export class KwilSigner {
     identifier: HexString | Uint8Array,
     signatureType?: AnySignatureType
   ) {
+    // set signer
     this.signer = signer;
+
+    // set identifier as bytes
     if (typeof identifier === 'string') {
       this.identifier = hexToBytes(identifier);
     } else {
       this.identifier = identifier;
     }
+
+    // set signature type, if supplied
     if (signatureType) {
       this.signatureType = signatureType;
     } else {
+
+      // infer signature type from signer
       this.signatureType = getSignatureType(signer);
+
+      // throw error if signature type could not be determined
       if (this.signatureType === SignatureType.SIGNATURE_TYPE_INVALID) {
         throw new Error(
           'Could not determine signature type from signer. Please pass a signature type to the KwilSigner constructor.'

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -44,14 +44,11 @@ async function test() {
         logging: true,
     })
 
-    const pubKey = await recoverPubKey(wallet)
     const kwilSigner = new KwilSigner(wallet, address)
     
-    const pubByte = hexToBytes(pubKey)
     const dbid = kwil.getDBID(address, "mydb")
-    logger(dbid)
     // await authenticate(kwil, kwilSigner)
-    // broadcast(kwil, testDB, wallet, address)
+    broadcast(kwil, testDB, kwilSigner)
     // broadcastEd25519(kwil, simpleDb)
     // await getTxInfo(kwil, txHash)
     // await getSchema(kwil, dbid)
@@ -101,20 +98,20 @@ async function getAccount(kwil, owner) {
     logger(hex)
 }
 
-async function broadcast(kwil, tx, sig, pK) {
+async function broadcast(kwil, tx, kwilSigner) {
     let ownedTx = tx
-    ownedTx.owner = pK
-    const readytx = await kwil
-        .dbBuilder()
-        .payload(ownedTx)
-        .signer(sig)
-        .publicKey(pK)
-        .chainId(chainId)
-        .buildTx()
+    ownedTx.owner = kwilSigner.identifier
 
-    console.log(readytx)
+    const payload = {
+        schema: ownedTx
+    }
 
-    const txHash = await kwil.broadcast(readytx)
+    const txHash = await kwil.deploy(
+        payload,
+        kwilSigner,
+        true
+    )
+  
     logger(txHash)
 }
 


### PR DESCRIPTION
Removed the variadic arguments from the CustomSigner signature. Previous definition was unclear. Now, only functions that match `(msg: Uint8Array) => Promise<Uint8Array>` will fit.

BREAKING CHANGE: Custom signers must match the signature `(msg: Uint8Array) => Promise<Uint8Array>`. The variadic arguments were removed.