### PR TITLE
feat: support typed parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwilteam/kwil-js",
-  "version": "0.6.2",
+  "version": "0.7.0-beta.0",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/builders/action_builder.ts
+++ b/src/builders/action_builder.ts
@@ -614,13 +614,13 @@ function analyzeNumber(num: number) {
   return analysis;
 }
 
-function analyzeDecimal(val: ValueType) {
+function analyzeDecimal(val: ValueType): { metadata: [number, number] | undefined} {
   if (val === null) {
-    return { varType: VarType.NULLSTR, metadata: undefined };
+    return { metadata: undefined };
   }
   
   if (val === undefined) {
-    return { varType: VarType.NULLSTR, metadata: undefined };
+    return { metadata: undefined };
   }
 
   if(Array.isArray(val)) {

--- a/src/builders/action_builder.ts
+++ b/src/builders/action_builder.ts
@@ -1,21 +1,23 @@
 import { Transaction } from '../core/tx';
 import { objects } from '../utils/objects';
-import { HexString, Nillable, NonNil, Promisy } from '../utils/types';
+import { Base64String, HexString, Nillable, NonNil, Promisy } from '../utils/types';
 import { Kwil } from '../client/kwil';
 import { ActionBuilder, SignerSupplier, PayloadBuilder } from '../core/builders';
 import { PayloadBuilderImpl } from './payload_builder';
 import { ActionInput } from '../core/action';
-import { EnvironmentType, PayloadType, ValueType } from '../core/enums';
+import { EnvironmentType, PayloadType, ValueType, VarType } from '../core/enums';
 import { AnySignatureType, SignatureType, getSignatureType } from '../core/signature';
-import { UnencodedActionPayload } from '../core/payload';
+import { CompiledDataType, EncodedValue, UnencodedActionPayload } from '../core/payload';
 import { Message } from '../core/message';
+import { DataType } from '../core/database';
+import { stringToBytes } from '../utils/serial';
+import { bytesToBase64 } from '../utils/base64';
 
 interface CheckSchema {
   dbid: string;
   name: string;
   modifiers?: ReadonlyArray<string>;
-  preparedActions: ValueType[][] | [];
-  nilArgs: boolean[][] | [];
+  preparedActions: EncodedValue[][];
 }
 
 interface ExecSchema {
@@ -291,7 +293,7 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
    */
   private async dobuildTx(actions: ActionInput[]): Promise<Transaction> {
     // retrieve the schema and run validations
-    const { dbid, name, preparedActions, modifiers, nilArgs } = await this.checkSchema(actions);
+    const { dbid, name, preparedActions, modifiers } = await this.checkSchema(actions);
 
     // throw runtime error if signer is null or undefined
     const signer = objects.requireNonNil(
@@ -327,7 +329,6 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
       dbid: dbid,
       action: name,
       arguments: preparedActions,
-      nilArgs: nilArgs,
     };
 
     // build the transaction
@@ -355,7 +356,7 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
    */
   private async doBuildMsg(action: ActionInput[]): Promise<Message> {
     // retrieve the schema and run validations
-    const { dbid, name, preparedActions, modifiers, nilArgs } = await this.checkSchema(action);
+    const { dbid, name, preparedActions, modifiers } = await this.checkSchema(action);
 
     // throw a runtime error if more than one set of inputs is trying to be executed. Call does not allow bulk execution.
     if (preparedActions && preparedActions.length > 1) {
@@ -379,7 +380,6 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
       // if there are prepared actions, then the first element in the array is the action inputs.
       arguments: preparedActions.length > 0 ? preparedActions[0] : [],
       // if there are nilArgs, then the first element in the array is the nilArgs.
-      nilArgs: nilArgs.length > 0 ? nilArgs[0] : [],
     };
 
     let msg: PayloadBuilder = PayloadBuilderImpl.of(this.kwil).payload(payload);
@@ -451,18 +451,13 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
     if (actions) {
       // ensure that no action inputs or values are missing
       const preparedActions = this.prepareActions(actions, execSchema, name);
-      const nilArgs = preparedActions.map((a1) => {
-        return a1.map((a2) => {
-          return a2 === null || a2 === undefined;
-        });
-      });
+     
 
       return {
         dbid: dbid,
         name: name,
         modifiers: execSchema.modifiers,
-        preparedActions: preparedActions,
-        nilArgs: nilArgs,
+        preparedActions
       };
     }
 
@@ -471,7 +466,6 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
       name: name,
       modifiers: execSchema.modifiers,
       preparedActions: [],
-      nilArgs: [],
     };
   };
 
@@ -487,7 +481,7 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
     actions: ActionInput[],
     execSchema: ExecSchema,
     actionName: string
-  ): ValueType[][] {
+  ): EncodedValue[][] {
     // if action does not require parameters, return an empty array
     if ((!execSchema.parameters || execSchema.parameters.length === 0) && actions.length === 0) {
       return [];
@@ -539,16 +533,11 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
         copy.put(p, val);
       });
 
+      
       if (missingInputs.size === 0) {
         execSchema.parameters && preparedActions.push(
           execSchema.parameters.map((p) => {
             const val = copy.get(p);
-
-            // because all values are technically strings under the kwildb hood, we need to convert all values that will resolve to a string to a string.
-            if (val?.toString()) {
-              return val.toString();
-            }
-
             return val
           })
         );
@@ -559,12 +548,103 @@ export class ActionBuilderImpl<T extends EnvironmentType> implements ActionBuild
       throw new Error(`Inputs are missing for actions: ${Array.from(missingInputs)}`);
     }
 
-    return preparedActions;
+    let encodedValues: EncodedValue[][] = [];
+
+    // construct the encoded value
+    preparedActions.forEach((action) => {
+      let singleEncodedValues: EncodedValue[] = [];
+      action.forEach((val) => {
+        const { metadata } = analyzeDecimal(val);
+
+        const metadataSpread = metadata ? { metadata } : {}
+
+        const dataType: DataType = {
+          name: val === null || val === undefined ? VarType.NULLSTR : VarType.TEXTSTR,
+          is_array: Array.isArray(val),
+          ...metadataSpread
+        }
+
+        let data: Base64String[] = []
+
+        if(Array.isArray(val)) {
+          data = val.map((v) => {
+            return v?.toString() || ''
+          })
+        } else {
+          data = [val?.toString() || '']
+        }
+
+        singleEncodedValues.push({
+          type: dataType,
+          data
+        })
+      })
+
+      encodedValues.push(singleEncodedValues)
+    })
+
+    return encodedValues;
   }
 
   private assertNotBuilding(): void {
     if (this._actions === TXN_BUILD_IN_PROGRESS) {
       throw new Error('Cannot modify the builder while a transaction is being built.');
     }
+  }
+}
+
+function analyzeNumber(num: number) {
+  // Convert the number to a string and handle potential negative sign
+  const numStr = Math.abs(num).toString();
+
+  // Check for the presence of a decimal point
+  const decimalIndex = numStr.indexOf('.');
+  const hasDecimal = decimalIndex !== -1;
+
+  // Calculate total digits (excluding the decimal point)
+  const totalDigits = hasDecimal ? numStr.length - 1 : numStr.length;
+
+  // Analysis object to hold the results
+  const analysis = {
+    hasDecimal: hasDecimal,
+    totalDigits: totalDigits,
+    decimalPosition: hasDecimal ? decimalIndex : -1
+  };
+
+  return analysis;
+}
+
+function analyzeDecimal(val: ValueType) {
+  if (val === null) {
+    return { varType: VarType.NULLSTR, metadata: undefined };
+  }
+  
+  if (val === undefined) {
+    return { varType: VarType.NULLSTR, metadata: undefined };
+  }
+
+  if(Array.isArray(val)) {
+    return analyzeDecimal(val[0])
+  }
+
+  let metadata: [number, number] | undefined;
+
+  switch (typeof val) {
+    case 'string':
+      break;
+    case 'number':
+      const numAnalysis = analyzeNumber(val);
+      if (numAnalysis.hasDecimal) {
+        metadata = [numAnalysis.totalDigits, numAnalysis.decimalPosition];
+      }
+      break;
+    case 'boolean':
+      break;
+    default:
+      throw new Error(`Unsupported type: ${typeof val}. If using a uuid, blob, or uint256, please convert to a JavaScript string.`);
+  }
+
+  return {
+    metadata
   }
 }

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -1,13 +1,13 @@
 import { objects } from '../utils/objects';
-import { EnvironmentType, ValueType } from './enums';
+import { ValueType } from './enums';
 
-export type Entry<T extends ValueType> = [string, T];
+export type Entry<T extends ValueType | ValueType[]> = [string, T];
 
-export type EntryType = Entry<ValueType>;
+export type EntryType = Entry<ValueType> | Entry<ValueType[]>;
 
-export type Entries = { [key: string]: ValueType };
+export type Entries = { [key: string]: ValueType | ValueType []};
 
-export type Predicate = (k: [key: string, v: ValueType]) => boolean;
+export type Predicate = (k: [key: string, v: ValueType | ValueType[]]) => boolean;
 
 /**
  * ActionBody is the interface for executing an action with the `kwil.execute()` method or calling an action with the `kwil.call()` method.
@@ -171,7 +171,7 @@ export class ActionInput implements Iterable<EntryType> {
    */
 
   public toArray(filter?: Predicate): ReadonlyArray<EntryType> {
-    return Object.entries(this.map).filter(filter ?? (() => true));
+    return Object.entries(this.map).filter(filter ?? (() => true)) as ReadonlyArray<EntryType>;
   }
 
   /**

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1,5 +1,5 @@
-import { AttributeType, VarType, IndexType } from './enums';
-import { CompiledKuneiform } from './payload';
+import { AttributeType, IndexType, VarType } from './enums';
+import { CompiledForeignProcedure, CompiledKuneiform, CompiledProcedure, CompiledTable } from './payload';
 
 /**
  * @typedef {Object} DeployBody is the interface for deploying a database with the `kwil.deploy()` method.
@@ -28,14 +28,10 @@ export interface DropBody {
 }
 
 // Encodable database is the same as database but procedures.returns can be an empty array
-export type EncodeableDatabase = Omit<Database, 'procedures' | 'foreign_calls'> & {
-  procedures: ReadonlyArray<Omit<Procedure, 'return_types'> & {
-    return_types: ProcedureReturn | Array<never>;
-  }>,
-  foreign_calls: ReadonlyArray<Omit<ForeignProcedure, 'returns'> & {
-    returns: ProcedureReturn | Array<never>;
-  }>,
-
+export type EncodeableDatabase = Omit<Database, 'tables' | 'procedures' | 'foreign_calls'> & {
+  tables: ReadonlyArray<CompiledTable>,
+  procedures: ReadonlyArray<CompiledProcedure>,
+  foreign_calls: ReadonlyArray<CompiledForeignProcedure>,
 };
 
 export interface Database {
@@ -120,8 +116,9 @@ export interface NamedType {
 }
 
 export interface DataType {
-  name: string;
+  name: VarType;
   is_array: boolean;
+  metadata?: [number, number] | Array<never> | null;
 }
 
 export interface ProcedureReturn {

--- a/src/core/enums.ts
+++ b/src/core/enums.ts
@@ -1,12 +1,17 @@
-export type ValueType = string | number | null | undefined;
+export type ValueType = string | number | null | undefined | Array<ValueType> | boolean;
 
+/**
+ * VarType is the type of the data in the database.
+ * 
+ * Although Kwil supports text, int, bool, blob, uuid, uint256, decimal, and null types, kwil-js only supports text, int, bool, decimal, and null. If you need to send blob, uuid, or uint256 types, you should send them as a javascript string.
+ * 
+ */
 export enum VarType {
-  NULL = 'null',
-  TEXT = 'text',
-  INT = 'int',
-  BOOL = 'bool',
-  BLOB = 'blob',
-  UUID = 'uuid',
+  TEXTSTR = 'text',
+  INTSTR = 'int',
+  BOOLSTR = 'bool',
+  DECIMALSTR = 'decimal',
+  NULLSTR = 'null',
   UNKNOWN = 'unknown',
 }
 

--- a/src/core/order.ts
+++ b/src/core/order.ts
@@ -24,15 +24,21 @@ export function enforceDatabaseOrder(db: NonNil<EncodeableDatabase>): NonNil<Enc
             return {
                 name: table.name,
                 columns: table.columns && table.columns.length > 0 ? table.columns?.map(column => {
+                    const metadataSpread = column.type.metadata ? { metadata: column.type.metadata } : {}
                     return {
                         name: column.name,
-                        type: column.type,
+                        type: {
+                            name: column.type.name,
+                            is_array: column.type.is_array,
+                            ...metadataSpread
+                        },
                         attributes: column.attributes?.map(attribute => {
                             return {
                                 type: attribute.type,
                                 value: attribute.value,
                             }
                         }),
+                       
                     }
                 }) : [],
                 indexes: table.indexes && table.indexes.length > 0 ? table.indexes?.map(index => {
@@ -71,9 +77,14 @@ export function enforceDatabaseOrder(db: NonNil<EncodeableDatabase>): NonNil<Enc
             return {
                 name: procedure.name,
                 parameters: procedure.parameters && procedure.parameters.length > 0 ? procedure.parameters?.map(parameter => {
+                    const metadataSpread = parameter.type.metadata ? { metadata: parameter.type.metadata } : {}
                     return {
                         name: parameter.name,
-                        type: parameter.type,
+                        type: {
+                            name: parameter.type.name,
+                            is_array: parameter.type.is_array,
+                            ...metadataSpread
+                        }
                     }
                 }) : [],
                 public: procedure.public,
@@ -87,9 +98,11 @@ export function enforceDatabaseOrder(db: NonNil<EncodeableDatabase>): NonNil<Enc
             return {
                 name: foreignCall.name,
                 parameters: foreignCall.parameters && foreignCall.parameters.length > 0 ? foreignCall.parameters?.map(parameter => {
+                    const metadataSpread = parameter.metadata ? { metadata: parameter.metadata } : {}
                     return {
                         name: parameter.name,
                         is_array: parameter.is_array,
+                        ...metadataSpread
                     }
                 }): [],
                 returns: foreignCall.returns

--- a/testing-functions/base_schema.json
+++ b/testing-functions/base_schema.json
@@ -8,7 +8,7 @@
       "columns": [
         {
           "name": "id",
-          "type": { "name": "uuid", "is_array": false },
+          "type": { "name": "uuid", "is_array": false, "metadata": null },
           "attributes": [{ "type": "PRIMARY_KEY", "value": "" }]
         }
       ],
@@ -26,7 +26,9 @@
       "body": "return 'hello world';",
       "return_types": {
         "is_table": false,
-        "fields": [{ "name": "message", "type": { "name": "text", "is_array": false } }]
+        "fields": [
+          { "name": "message", "type": { "name": "text", "is_array": false, "metadata": null } }
+        ]
       },
       "annotations": null
     },

--- a/testing-functions/mydb.json
+++ b/testing-functions/mydb.json
@@ -8,7 +8,7 @@
       "columns": [
         {
           "name": "id",
-          "type": { "name": "int", "is_array": false },
+          "type": { "name": "int", "is_array": false, "metadata": null },
           "attributes": [
             { "type": "PRIMARY_KEY", "value": "" },
             { "type": "NOT_NULL", "value": "" }
@@ -16,17 +16,17 @@
         },
         {
           "name": "name",
-          "type": { "name": "text", "is_array": false },
+          "type": { "name": "text", "is_array": false, "metadata": null },
           "attributes": [{ "type": "NOT_NULL", "value": "" }]
         },
         {
           "name": "post_title",
-          "type": { "name": "text", "is_array": false },
+          "type": { "name": "text", "is_array": false, "metadata": null },
           "attributes": [{ "type": "NOT_NULL", "value": "" }]
         },
         {
           "name": "post_body",
-          "type": { "name": "text", "is_array": false },
+          "type": { "name": "text", "is_array": false, "metadata": null },
           "attributes": [{ "type": "NOT_NULL", "value": "" }]
         }
       ],
@@ -96,9 +96,9 @@
     {
       "name": "proc_add_user",
       "parameters": [
-        { "name": "$user", "type": { "name": "text", "is_array": false } },
-        { "name": "$title", "type": { "name": "text", "is_array": false } },
-        { "name": "$body", "type": { "name": "text", "is_array": false } }
+        { "name": "$user", "type": { "name": "text", "is_array": false, "metadata": null } },
+        { "name": "$title", "type": { "name": "text", "is_array": false, "metadata": null } },
+        { "name": "$body", "type": { "name": "text", "is_array": false, "metadata": null } }
       ],
       "public": true,
       "modifiers": null,
@@ -108,34 +108,42 @@
     },
     {
       "name": "get_post_by_id",
-      "parameters": [{ "name": "$id", "type": { "name": "int", "is_array": false } }],
+      "parameters": [
+        { "name": "$id", "type": { "name": "int", "is_array": false, "metadata": null } }
+      ],
       "public": true,
       "modifiers": ["VIEW"],
       "body": "for $row in SELECT post_title, post_body FROM posts WHERE id = $id {\n        return $row.post_title, $row.post_body; // will return on the first iteration\n    }\n\n    error(format('record with id = \"%s\" not found', $id));",
       "return_types": {
         "is_table": false,
         "fields": [
-          { "name": "title", "type": { "name": "text", "is_array": false } },
-          { "name": "body", "type": { "name": "text", "is_array": false } }
+          { "name": "title", "type": { "name": "text", "is_array": false, "metadata": null } },
+          { "name": "body", "type": { "name": "text", "is_array": false, "metadata": null } }
         ]
       },
       "annotations": null
     },
     {
       "name": "proc_call_base",
-      "parameters": [{ "name": "$dbid", "type": { "name": "text", "is_array": false } }],
+      "parameters": [
+        { "name": "$dbid", "type": { "name": "text", "is_array": false, "metadata": null } }
+      ],
       "public": true,
       "modifiers": ["VIEW"],
-      "body": "$message text := call_base_view[$dbid, 'return_hello']();\n    return $message;",
+      "body": "$message text := call_base_view[$dbid, 'return_hello']('hello');\n    return $message;",
       "return_types": {
         "is_table": false,
-        "fields": [{ "name": "original", "type": { "name": "text", "is_array": false } }]
+        "fields": [
+          { "name": "original", "type": { "name": "text", "is_array": false, "metadata": null } }
+        ]
       },
       "annotations": null
     },
     {
       "name": "proc_insert_base",
-      "parameters": [{ "name": "$dbid", "type": { "name": "text", "is_array": false } }],
+      "parameters": [
+        { "name": "$dbid", "type": { "name": "text", "is_array": false, "metadata": null } }
+      ],
       "public": true,
       "modifiers": null,
       "body": "call_base_insert[$dbid, 'add_foo']();",
@@ -146,10 +154,12 @@
   "foreign_calls": [
     {
       "name": "call_base_view",
-      "parameters": null,
+      "parameters": [{ "name": "text", "is_array": false, "metadata": null }],
       "returns": {
         "is_table": false,
-        "fields": [{ "name": "col0", "type": { "name": "text", "is_array": false } }]
+        "fields": [
+          { "name": "col0", "type": { "name": "text", "is_array": false, "metadata": null } }
+        ]
       }
     },
     { "name": "call_base_insert", "parameters": null, "returns": null }

--- a/testing-functions/mydb.json
+++ b/testing-functions/mydb.json
@@ -130,7 +130,7 @@
       ],
       "public": true,
       "modifiers": ["VIEW"],
-      "body": "$message text := call_base_view[$dbid, 'return_hello']('hello');\n    return $message;",
+      "body": "$message text := call_base_view[$dbid, 'return_hello']();\n    return $message;",
       "return_types": {
         "is_table": false,
         "fields": [
@@ -154,7 +154,7 @@
   "foreign_calls": [
     {
       "name": "call_base_view",
-      "parameters": [{ "name": "text", "is_array": false, "metadata": null }],
+      "parameters": null,
       "returns": {
         "is_table": false,
         "fields": [

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -70,7 +70,7 @@ async function test() {
 
     const dbid = kwil.getDBID(address, "mydb")
     // await authenticate(kwil, kwilSigner)
-    // broadcast(kwil, testDB, kwilSigner)
+    broadcast(kwil, testDB, kwilSigner)
     // broadcastEd25519(kwil, testDB)
     // await getTxInfo(kwil, txHash)
     // await getSchema(kwil, dbid)
@@ -91,10 +91,13 @@ async function test() {
     // await dropDb(kwil, dbid, wallet, address)
     // await transfer(kwil, "0x7e5f4552091a69125d5dfcb7b8c2659029395bdf", 20, kwilSigner)
     // bulkActionInput(kwil, kwilSigner)
-    executeGeneralAction(kwil, dbid, "proc_insert_base", kwilSigner, {
-        "$dbid": kwil.getDBID(address, "base_schema")
-    })
-    // executeGeneralView(kwil, dbid, "proc_call_base", {
+    // executeGeneralAction(kwil, dbid, "proc_insert_base", kwilSigner, {
+    //     $id: 1,
+    //     $user: 'luke',
+    //     $title: 'Test post',
+    //     $body: 'This is a test post'
+    // })
+    // executeGeneralView(kwil, dbid, "proc_insert_base", {
     //     "$dbid": kwil.getDBID(address, "base_schema")
     // })
 }

--- a/tests/kwil.test.ts
+++ b/tests/kwil.test.ts
@@ -420,11 +420,9 @@ describe('Testing case insentivity on test_db', () => {
   });
 
   it('should return an expired cookie when logging out', async () => {
-    //@ts-ignore
+    // @ts-ignore
     const preCookie = kwil.cookie;
-    console.log(kwil)
     const result = await kwil.auth.logout();
-    console.log('result:', result)
 
     //@ts-ignore
     const postCookie = kwil.cookie;

--- a/tests/test_schema2.json
+++ b/tests/test_schema2.json
@@ -1,6 +1,6 @@
 {
   "name": "testdb",
-  "owner": null,
+  "owner": "",
   "extensions": null,
   "tables": [
     {
@@ -8,47 +8,29 @@
       "columns": [
         {
           "name": "id",
-          "type": {
-            "name": "int",
-            "is_array": false
-          },
+          "type": { "name": "int", "is_array": false, "metadata": null },
           "attributes": [
-            {
-              "type": "PRIMARY_KEY"
-            },
-            {
-              "type": "NOT_NULL"
-            }
+            { "type": "PRIMARY_KEY", "value": "" },
+            { "type": "NOT_NULL", "value": "" }
           ]
         },
         {
           "name": "username",
-          "type": {
-            "name": "text",
-            "is_array": false
-          }
+          "type": { "name": "text", "is_array": false, "metadata": null },
+          "attributes": null
         },
         {
           "name": "age",
-          "type": {
-            "name": "int",
-            "is_array": false
-          },
-          "attributes": [
-            {
-              "type": "MIN",
-              "value": "0"
-            }
-          ]
+          "type": { "name": "int", "is_array": false, "metadata": null },
+          "attributes": [{ "type": "MIN", "value": "0" }]
         },
         {
           "name": "wallet",
-          "type": {
-            "name": "text",
-            "is_array": false
-          }
+          "type": { "name": "text", "is_array": false, "metadata": null },
+          "attributes": null
         }
       ],
+      "indexes": null,
       "foreign_keys": null
     },
     {
@@ -56,56 +38,30 @@
       "columns": [
         {
           "name": "id",
-          "type": {
-            "name": "int",
-            "is_array": false
-          },
+          "type": { "name": "int", "is_array": false, "metadata": null },
           "attributes": [
-            {
-              "type": "PRIMARY_KEY"
-            },
-            {
-              "type": "NOT_NULL"
-            }
+            { "type": "PRIMARY_KEY", "value": "" },
+            { "type": "NOT_NULL", "value": "" }
           ]
         },
         {
           "name": "user_id",
-          "type": {
-            "name": "int",
-            "is_array": false
-          }
+          "type": { "name": "int", "is_array": false, "metadata": null },
+          "attributes": null
         },
         {
           "name": "title",
-          "type": {
-            "name": "text",
-            "is_array": false
-          }
+          "type": { "name": "text", "is_array": false, "metadata": null },
+          "attributes": null
         },
         {
           "name": "content",
-          "type": {
-            "name": "text",
-            "is_array": false
-          },
-          "attributes": [
-            {
-              "type": "MAX_LENGTH",
-              "value": "1000"
-            }
-          ]
+          "type": { "name": "text", "is_array": false, "metadata": null },
+          "attributes": [{ "type": "MAX_LENGTH", "value": "1000" }]
         }
       ],
       "indexes": [
-        {
-          "name": "unique_index",
-          "columns": [
-            "user_id",
-            "title"
-          ],
-          "type": "UNIQUE_BTREE"
-        }
+        { "name": "unique_index", "columns": ["user_id", "title"], "type": "UNIQUE_BTREE" }
       ],
       "foreign_keys": null
     }
@@ -113,26 +69,23 @@
   "actions": [
     {
       "name": "createusertest",
-      "parameters": [
-        "$id",
-        "$username",
-        "$age"
-      ],
+      "annotations": null,
+      "parameters": ["$id", "$username", "$age"],
       "public": true,
       "modifiers": null,
       "body": "INSERT INTO users( id , username , age , wallet ) VALUES ( $id , $username , $age , @caller );"
     },
     {
       "name": "update_username",
-      "parameters": [
-        "$username"
-      ],
+      "annotations": null,
+      "parameters": ["$username"],
       "public": true,
       "modifiers": null,
       "body": "UPDATE users SET username = $username WHERE wallet = @caller;"
     },
     {
       "name": "delete_user",
+      "annotations": null,
       "parameters": null,
       "public": true,
       "modifiers": null,
@@ -140,62 +93,50 @@
     },
     {
       "name": "create_post",
-      "parameters": [
-        "$id",
-        "$title",
-        "$content"
-      ],
+      "annotations": null,
+      "parameters": ["$id", "$title", "$content"],
       "public": true,
       "modifiers": null,
       "body": "INSERT INTO posts( id , user_id , title , content ) VALUES ( $id , ( SELECT id FROM users WHERE wallet = @caller ) , $title , $content );"
     },
     {
       "name": "delete_post",
-      "parameters": [
-        "$id"
-      ],
+      "annotations": null,
+      "parameters": ["$id"],
       "public": true,
       "modifiers": null,
       "body": "DELETE FROM posts WHERE id = $id AND user_id =( SELECT id FROM users WHERE wallet = @caller );"
     },
     {
       "name": "get_user_by_wallet",
-      "parameters": [
-        "$address"
-      ],
+      "annotations": null,
+      "parameters": ["$address"],
       "public": true,
-      "modifiers": [
-        "VIEW"
-      ],
+      "modifiers": ["VIEW"],
       "body": "SELECT * FROM users WHERE wallet = $address;"
     },
     {
       "name": "list_users",
+      "annotations": null,
       "parameters": null,
       "public": true,
-      "modifiers": [
-        "VIEW"
-      ],
+      "modifiers": ["VIEW"],
       "body": "SELECT * FROM users;"
     },
     {
       "name": "get_user_posts",
-      "parameters": [
-        "$username"
-      ],
+      "annotations": null,
+      "parameters": ["$username"],
       "public": true,
-      "modifiers": [
-        "VIEW"
-      ],
+      "modifiers": ["VIEW"],
       "body": "SELECT title , content FROM posts WHERE user_id =( SELECT id FROM users WHERE username = $username );"
     },
     {
       "name": "multi_select",
+      "annotations": null,
       "parameters": null,
       "public": true,
-      "modifiers": [
-        "VIEW"
-      ],
+      "modifiers": ["VIEW"],
       "body": "SELECT * FROM posts;\n    SELECT * FROM users;"
     }
   ],

--- a/tests/variable_test.kf
+++ b/tests/variable_test.kf
@@ -1,0 +1,40 @@
+database variable_test;
+
+table var_table {
+    uuid_col uuid primary,
+    text_col text,
+    int_col int,
+    bool_col bool,
+    blob_col blob,
+    uint256_col uint256
+}
+
+action insert_uuid ($id) public {
+    INSERT INTO var_table(uuid_col)
+    VALUES ($id);
+}
+
+action insert_text ($id, $text) public {
+    INSERT INTO var_table (uuid_col, text_col)
+    VALUES ($id, $text);
+}
+
+action insert_int ($id, $int) public {
+    INSERT INTO var_table (uuid_col, int_col)
+    VALUES($id, $int);
+}
+
+action insert_bool ($id, $bool) public {
+    INSERT INTO var_table (uuid_col, bool_col)
+    VALUES ($id, $bool);
+}
+
+action insert_blob ($id, $blob) public {
+    INSERT INTO var_table (uuid_col, blob_col)
+    VALUES ($id, $blob);
+}
+
+action insert_uint256 ($id, $uint256) public {
+    INSERT INTO var_table (uuid_col, uint256_col)
+    VALUES ($id, $uint256);
+}


### PR DESCRIPTION
Add typed paramters to Database interface and adjust all helper classes accordingly.

BREAKING CHANGE: The internal database and action payload interfaces are now aligned with kwil v0.8 beta-0. From this commit on, you should only use kwil-db versions v0.8-beta+.