### PR TITLE
refactor(database): change procedure return key

### DIFF
--- a/src/builders/db_builder.ts
+++ b/src/builders/db_builder.ts
@@ -561,16 +561,16 @@ export class DBBuilderImpl<T extends DeployOrDrop, U extends EnvironmentType>
             }
           });
 
-        if (!foreignCall.returns) {
-          foreignCall.returns = [];
+        if (!foreignCall.return_types) {
+          foreignCall.return_types = [];
         }
 
-        if (!Array.isArray(foreignCall.returns)) {
-          if (!foreignCall.returns.is_table) {
-            foreignCall.returns.is_table = false;
+        if (!Array.isArray(foreignCall.return_types)) {
+          if (!foreignCall.return_types.is_table) {
+            foreignCall.return_types.is_table = false;
           }
 
-          foreignCall.returns.fields.forEach((field) => {
+          foreignCall.return_types.fields.forEach((field) => {
             if (!field.name) {
               field.name = ''
             }

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -134,5 +134,5 @@ export interface SelectQuery {
 export interface ForeignProcedure {
   name: string;
   parameters: ReadonlyArray<DataType>;
-  returns: ProcedureReturn;
+  return_types: ProcedureReturn;
 }

--- a/src/core/order.ts
+++ b/src/core/order.ts
@@ -105,7 +105,7 @@ export function enforceDatabaseOrder(db: NonNil<EncodeableDatabase>): NonNil<Enc
                         ...metadataSpread
                     }
                 }): [],
-                returns: foreignCall.returns
+                return_types: foreignCall.return_types
             }
         }): [],
     }

--- a/src/core/payload.ts
+++ b/src/core/payload.ts
@@ -100,7 +100,7 @@ type CompiledNamedType = Omit<NamedType, 'type'> & {
     type: CompiledDataType;
 }
 
-export type CompiledForeignProcedure = Omit<ForeignProcedure, 'returns' | 'parameters'> & {
+export type CompiledForeignProcedure = Omit<ForeignProcedure, 'return_types' | 'parameters'> & {
     parameters: ReadonlyArray<CompiledDataType>
-    returns: CompiledProcedureReturn | Array<never>;
+    return_types: CompiledProcedureReturn | Array<never>;
 }

--- a/testing-functions/mydb.json
+++ b/testing-functions/mydb.json
@@ -155,13 +155,13 @@
     {
       "name": "call_base_view",
       "parameters": null,
-      "returns": {
+      "return_types": {
         "is_table": false,
         "fields": [
           { "name": "col0", "type": { "name": "text", "is_array": false, "metadata": null } }
         ]
       }
     },
-    { "name": "call_base_insert", "parameters": null, "returns": null }
+    { "name": "call_base_insert", "parameters": null, "return_types": null }
   ]
 }

--- a/tests/kwil.test.ts
+++ b/tests/kwil.test.ts
@@ -855,7 +855,7 @@ import { v4 as uuidV4 } from 'uuid';
 import { stringToBytes } from '../dist/utils/serial';
 import { bytesToBase64 } from '../dist/utils/base64';
 
-describe.only('Kwil DB types', () => {
+describe('Kwil DB types', () => {
   const kwilSigner = new KwilSigner(wallet, address);
   const dbid = kwil.getDBID(address, 'variable_test');
 
@@ -885,7 +885,7 @@ describe.only('Kwil DB types', () => {
     expect(res.data).toBeDefined();
     expect(res.status).toBe(200);
 
-    const query = await kwil.selectQuery(dbid, `SELECT * FROM var_table WHERE uuid_col = '${uuid}'`);
+    const query = await kwil.selectQuery(dbid, `SELECT * FROM var_table WHERE uuid_col = '${uuid}'::uuid`);
     expect(query.data).toBeDefined();
     expect(query.data).toHaveLength(1);
   }, 10000);
@@ -980,7 +980,7 @@ describe.only('Kwil DB types', () => {
     expect(res.data).toBeDefined();
     expect(res.status).toBe(200);
 
-    const query = await kwil.selectQuery(dbid, `SELECT * FROM var_table WHERE uuid_col = '${id}'`);
+    const query = await kwil.selectQuery(dbid, `SELECT * FROM var_table WHERE uuid_col = '${id}'::uuid`);
 
     expect(query.data).toBeDefined();
     expect(query.data).toHaveLength(1);
@@ -1004,7 +1004,7 @@ describe.only('Kwil DB types', () => {
     expect(res.data).toBeDefined();
     expect(res.status).toBe(200);
 
-    const query = await kwil.selectQuery(dbid, `SELECT * FROM var_table WHERE blob_col = '${blob}'`);
+    const query = await kwil.selectQuery(dbid, `SELECT * FROM var_table WHERE blob_col = '${blob}'::blob`);
 
     expect(query.data).toBeDefined();
     expect(query.data).toHaveLength(1);

--- a/tests/variable_test.kf
+++ b/tests/variable_test.kf
@@ -5,6 +5,7 @@ table var_table {
     text_col text,
     int_col int,
     bool_col bool,
+    dec_col decimal(5,2),
     blob_col blob,
     uint256_col uint256
 }
@@ -22,6 +23,11 @@ action insert_text ($id, $text) public {
 action insert_int ($id, $int) public {
     INSERT INTO var_table (uuid_col, int_col)
     VALUES($id, $int);
+}
+
+action insert_dec ($id, $dec) public {
+    INSERT INTO var_table (uuid_col, dec_col)
+    VALUES($id, $dec);
 }
 
 action insert_bool ($id, $bool) public {


### PR DESCRIPTION
Change foreign procedure `return` field to `return_types` to work with changes in https://github.com/kwilteam/kwil-db/pull/794