### PR TITLE
Remove HTTP status 200 in tests / chain info fix

### DIFF
--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -215,7 +215,13 @@ export default class Client extends Api {
 
     const res = await super.post<JsonRPCResponse<ChainInfoResponse>>(`/rpc/v1`, body);
 
-    return checkRes(res, (r) => r.result);
+    return checkRes(res, (r) => {
+      return {
+        chain_id: r.result.chain_id,
+        height: r.result.block_height.toString(),
+        hash: r.result.block_hash
+      }
+    });
   }
 
   protected async selectQueryClient(query: SelectQuery): Promise<GenericResponse<Object[]>> {

--- a/src/core/jsonrpc.ts
+++ b/src/core/jsonrpc.ts
@@ -118,7 +118,11 @@ interface Result {
     result: Base64String;
 }
 
-export type ChainInfoResponse = ChainInfo;
+export interface ChainInfoResponse {
+    chain_id: string;
+    block_height: number;
+    block_hash: string;
+}
 
 export interface ListDatabasesResponse {
     databases?: DatasetInfoServer[];

--- a/test-eth-app/package-lock.json
+++ b/test-eth-app/package-lock.json
@@ -8,7 +8,7 @@
       "name": "testapp",
       "version": "0.0.0",
       "dependencies": {
-        "@kwilteam/kwil-js": "^0.6.3",
+        "@kwilteam/kwil-js": "^0.7.1",
         "ethers": "^6.8.1",
         "ethers5": "npm:ethers@^5.7.2",
         "react": "^18.2.0",
@@ -1684,9 +1684,9 @@
       }
     },
     "node_modules/@kwilteam/kwil-js": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@kwilteam/kwil-js/-/kwil-js-0.6.3.tgz",
-      "integrity": "sha512-v7rM5JbuBDRl/f6yfw1mw+xKBnhO8nosSinhnGl/bLkTKCex5aBP7ZgBPXJBC20OibJkyDxi+gDvRw2uDjTn1w==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@kwilteam/kwil-js/-/kwil-js-0.7.1.tgz",
+      "integrity": "sha512-aeqgMmg9q1NNNxkA1LKEAOv0HnYFpQimt9B1o26uiqslC1l7qbJuKfQ35W7HG2hhZs/5+mwJPZQizmPgF4GwIg==",
       "dependencies": {
         "axios": "^0.27.2",
         "ethers": "^6.9.1",

--- a/test-eth-app/package.json
+++ b/test-eth-app/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@kwilteam/kwil-js": "^0.6.3",
+    "@kwilteam/kwil-js": "^0.7.1",
     "ethers": "^6.8.1",
     "ethers5": "npm:ethers@^5.7.2",
     "react": "^18.2.0",


### PR DESCRIPTION
Removes HTTP status 200 as a success case on many integration tests.

I also uncovered a bug in the `chainInfo` method where the property names returned from kwild did not match what kwil-js expected (e.g., kwil-js expected `height`, kwild returned `block_height`). To prevent making a breaking change in kwil-js, I mapped the properties kwild returned to the properties kwil-js expected.
