### PR TITLE
fix(kwil): separate authentication errors from call errors

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -103,7 +103,7 @@ export class Auth<T extends EnvironmentType> {
 
     // Check if challenge.data is undefined
     if (!msgChallenge) {
-      throw new Error('Challenge data is undefined. Unable to authenticate in private mode.');
+      throw new Error('Challenge data is undefined. Something went wrong.');
     }
 
     // Check if multiple inputs were provided


### PR DESCRIPTION
There was a minor bug where, when a call failed in private mode, the call error was thrown as part of the authentication error stack, regardless of whether the call failure was related to authentication. This commit separates the logic so that only authentication errors are thrown in the authentication stack.