### PR TITLE
fix(kwil.call): return decimals as strings

### DIFF
--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -15,6 +15,7 @@ import { BroadcastSyncType, BytesEncodingStatus, EnvironmentType } from '../core
 import { AuthInfo, AuthSuccess, AuthenticatedBody, LogoutResponse } from '../core/auth';
 import { AxiosResponse } from 'axios';
 import { AccountRequest, AccountResponse, AccountStatus, AuthParamRequest, AuthParamResponse, AuthnLogoutRequest, AuthnRequest, AuthnResponse, BroadcastRequest, BroadcastResponse, CallRequest, CallResponse, ChainInfoRequest, ChainInfoResponse, EstimatePriceRequest, EstimatePriceResponse, JSONRPCMethod, JsonRPCRequest, JsonRPCResponse, ListDatabasesRequest, ListDatabasesResponse, PingRequest, PingResponse, QueryRequest, QueryResponse, SchemaRequest, SchemaResponse, TxQueryRequest, TxQueryResponse } from '../core/jsonrpc';
+import { parseWithSafeInt } from '../utils/integer';
 
 export default class Client extends Api {
   private unconfirmedNonce: boolean;
@@ -227,7 +228,7 @@ export default class Client extends Api {
     const res = await super.post<JsonRPCResponse<QueryResponse>>(`/rpc/v1`, body);
 
     return checkRes(res, (r) => {
-      return JSON.parse(bytesToString(base64ToBytes(r.result.result))) as Object[];
+      return parseWithSafeInt(bytesToString(base64ToBytes(r.result.result))) as Object[];
     });
   }
 
@@ -263,7 +264,7 @@ export default class Client extends Api {
   protected async callClient(msg: Message): Promise<GenericResponse<MsgReceipt>> {
     const body = this.buildJsonRpcRequest<CallRequest>(
       JSONRPCMethod.METHOD_CALL,
-      { 
+      {
         body: msg.body,
         auth_type: msg.auth_type,
         sender: msg.sender || '',
@@ -284,7 +285,7 @@ export default class Client extends Api {
 
     return checkRes(res, (r) => {
       return {
-        result: JSON.parse(bytesToString(base64ToBytes(r.result.result)))
+        result: parseWithSafeInt(bytesToString(base64ToBytes(r.result.result)))
       }
     });
   }

--- a/src/utils/integer.ts
+++ b/src/utils/integer.ts
@@ -1,0 +1,65 @@
+// function that separates
+// *big numbers* from *small* ones
+//
+// (works for input parameter num of type number/string)
+// null is accounted for because of the regex
+
+const isBigNumber = (num: number | string | null): boolean => {
+    if (num === null) {
+        return false;
+    }
+
+    if (typeof num === 'number') {
+        return +num >= Number.MAX_SAFE_INTEGER || +num <= Number.MIN_SAFE_INTEGER;
+    }
+
+    if (typeof num === 'string') {
+        return num.length > Number.MAX_SAFE_INTEGER.toString().length || num.length > Number.MIN_SAFE_INTEGER.toString().length;
+    }
+
+    return false;
+}
+
+// function that checks if a number is a decimal
+// (works for input parameter num of type number/string)
+// null is accounted for because of the regex
+const isDecimal = (num: number | string | null): boolean => {
+    if (num === null) {
+        return false;
+    }
+
+    if (typeof num === 'number') {
+        return Number.isInteger(num);
+    }
+
+    if (typeof num === 'string') {
+        return num.includes('.');
+    }
+
+    return false;
+}
+
+// on some machines, our bytesToString function already has the appropriate quotes,
+// so we need to remove the extra quotes that we add in the bytesToString function
+const removeExtraDoubleQuotes = (jsonString: string) => {
+    return jsonString.replace(/""([^"]+)""/g, '"$1"');
+};
+
+// function that enquotes numbers that are not safe or
+// are decimals in a JSON string
+// this helps us clean up the JSON string before parsing
+
+const enquoteBigNumOrDecimal = (jsonString: string) =>
+    jsonString.replaceAll(
+        /([:\s\[,]*)(\d+(?:\.\d+)?)([\s,\]]*)/g,
+        (matchingSubstr, prefix, num, suffix) => 
+            isBigNumber(num) || isDecimal(num)
+                ? `${prefix}"${num}"${suffix}`
+                : matchingSubstr
+    );
+
+
+// parser that turns matching *big numbers* in
+// source JSON string to bigint
+export const parseWithSafeInt = (jsonString: string) => 
+    JSON.parse(removeExtraDoubleQuotes(enquoteBigNumOrDecimal(jsonString)));

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -105,7 +105,7 @@ async function executeGeneralView(kwil, dbid, name, input) {
     const body = {
         name,
         dbid,
-        inputs: [ input ]
+        inputs: [ input ] 
     }
 
     const res = await kwil.call(body)

--- a/tests/variable_test.json
+++ b/tests/variable_test.json
@@ -8,22 +8,22 @@
       "columns": [
         {
           "name": "uuid_col",
-          "type": { "name": "uuid", "is_array": false, "metadata": null },
+          "type": { "name": "uuid", "is_array": false, "metadata": [0, 0] },
           "attributes": [{ "type": "PRIMARY_KEY", "value": "" }]
         },
         {
           "name": "text_col",
-          "type": { "name": "text", "is_array": false, "metadata": null },
+          "type": { "name": "text", "is_array": false, "metadata": [0, 0] },
           "attributes": null
         },
         {
           "name": "int_col",
-          "type": { "name": "int", "is_array": false, "metadata": null },
+          "type": { "name": "int", "is_array": false, "metadata": [0, 0] },
           "attributes": null
         },
         {
           "name": "bool_col",
-          "type": { "name": "bool", "is_array": false, "metadata": null },
+          "type": { "name": "bool", "is_array": false, "metadata": [0, 0] },
           "attributes": null
         },
         {
@@ -32,13 +32,18 @@
           "attributes": null
         },
         {
+          "name": "big_dec_col",
+          "type": { "name": "decimal", "is_array": false, "metadata": [20, 10] },
+          "attributes": null
+        },
+        {
           "name": "blob_col",
-          "type": { "name": "blob", "is_array": false, "metadata": null },
+          "type": { "name": "blob", "is_array": false, "metadata": [0, 0] },
           "attributes": null
         },
         {
           "name": "uint256_col",
-          "type": { "name": "uint256", "is_array": false, "metadata": null },
+          "type": { "name": "uint256", "is_array": false, "metadata": [0, 0] },
           "attributes": null
         }
       ],
@@ -72,20 +77,20 @@
       "body": "INSERT INTO var_table (uuid_col, int_col)\n    VALUES($id, $int);"
     },
     {
+      "name": "insert_dec",
+      "annotations": null,
+      "parameters": ["$id", "$dec"],
+      "public": true,
+      "modifiers": null,
+      "body": "INSERT INTO var_table (uuid_col, dec_col)\n    VALUES($id, $dec);"
+    },
+    {
       "name": "insert_bool",
       "annotations": null,
       "parameters": ["$id", "$bool"],
       "public": true,
       "modifiers": null,
       "body": "INSERT INTO var_table (uuid_col, bool_col)\n    VALUES ($id, $bool);"
-    },
-    {
-      "name": "insert_dec",
-      "annotations": null,
-      "parameters": ["$id", "$dec"],
-      "public": true,
-      "modifiers": null,
-      "body": "INSERT INTO var_table(uuid_col, dec_col)\n    VALUES ($id, $dec);"
     },
     {
       "name": "insert_blob",
@@ -104,6 +109,22 @@
       "body": "INSERT INTO var_table (uuid_col, uint256_col)\n    VALUES ($id, $uint256);"
     }
   ],
-  "procedures": null,
+  "procedures": [
+    {
+      "name": "insert_big_dec",
+      "parameters": [
+        { "name": "$id", "type": { "name": "uuid", "is_array": false, "metadata": [0, 0] } },
+        {
+          "name": "$big_dec",
+          "type": { "name": "decimal", "is_array": false, "metadata": [20, 10] }
+        }
+      ],
+      "public": true,
+      "modifiers": null,
+      "body": "INSERT INTO var_table (uuid_col, big_dec_col)\n    VALUES ($id, $big_dec);",
+      "return_types": null,
+      "annotations": null
+    }
+  ],
   "foreign_calls": null
 }

--- a/tests/variable_test.kf
+++ b/tests/variable_test.kf
@@ -6,6 +6,7 @@ table var_table {
     int_col int,
     bool_col bool,
     dec_col decimal(5,2),
+    big_dec_col decimal(20, 10),
     blob_col blob,
     uint256_col uint256
 }
@@ -43,4 +44,9 @@ action insert_blob ($id, $blob) public {
 action insert_uint256 ($id, $uint256) public {
     INSERT INTO var_table (uuid_col, uint256_col)
     VALUES ($id, $uint256);
+}
+
+action insert_big_dec ($id, $big_dec) public {
+    INSERT INTO var_table (uuid_col, big_dec_col)
+    VALUES ($id, $big_dec);
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2020", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "target": "ES2021", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
     "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
     "strict": true, /* Enable all strict type-checking options. */
     "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */


### PR DESCRIPTION
Fixed bug where decimals returned as integers, causing the decimals to lose precision (esp in cases where the decimal size is > max safe length).