### PR TITLE
feat(call, selectquery): typescript generics for call/selectQuery response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+## [0.9.0-beta.2](https://github.com/kwilteam/kwil-js/compare/v0.9.0-beta.1...v0.9.0-beta.2) (2025-02-12)
+
+
+### Features
+
+* **call, selectquery:** typescript generics for call/selectQuery reesponse ([92d932a](https://github.com/kwilteam/kwil-js/commit/92d932a6a208f2d7374fcbbf7ee2b404ccd6026e))
+
 ## [0.9.0-beta.1](https://github.com/kwilteam/kwil-js/compare/v0.8.6...v0.9.0-beta.1) (2025-02-07)
 
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@kwilteam/kwil-js",
-  "version": "0.9.0-beta.1",
+  "version": "0.9.0-beta.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@kwilteam/kwil-js",
-      "version": "0.9.0-beta.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "axios": "^0.27.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kwilteam/kwil-js",
-  "version": "0.9.0-beta.1",
+  "version": "0.9.0-beta.2",
   "description": "",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -284,7 +284,7 @@ export default class Client extends Api {
     });
   }
 
-  protected async callClient(msg: Message): Promise<CallClientResponse<Object[]>> {
+  protected async callClient(msg: Message): Promise<CallClientResponse<any[]>> {
     const body = this.buildJsonRpcRequest<CallRequest>(JSONRPCMethod.METHOD_CALL, {
       body: msg.body,
       auth_type: msg.auth_type,

--- a/src/client/kwil.ts
+++ b/src/client/kwil.ts
@@ -175,7 +175,7 @@ export abstract class Kwil<T extends EnvironmentType> extends Client {
    * @param params - Optional array of parameters to bind to the query ($1, $2, etc.)
    * @returns Promise resolving to query results
    */
-  public async selectQuery(query: string, params?: QueryParams): Promise<GenericResponse<Object[]>>;
+  public async selectQuery<T extends Object>(query: string, params?: QueryParams): Promise<GenericResponse<T[]>>;
   /**
    * @deprecated Use selectQuery(query, params?) instead. This method will be removed in next major version.
    */
@@ -422,11 +422,11 @@ export abstract class Kwil<T extends EnvironmentType> extends Client {
    * @param {(...args: any) => void} cookieHandlerCallback (optional) - the callback to handle the cookie if in the NODE environment
    * @returns A promise that resolves to the receipt of the message.
    */
-  protected async baseCall(
+  protected async baseCall<T extends Object>(
     callBody: CallBody,
     kwilSigner?: KwilSigner,
     cookieHandlerCallback?: { setCookie: () => void; resetCookie: () => void }
-  ): Promise<GenericResponse<Object[]>> {
+  ): Promise<GenericResponse<T[]>> {
     // Ensure auth mode is set
     await this.ensureAuthenticationMode();
 
@@ -448,7 +448,7 @@ export abstract class Kwil<T extends EnvironmentType> extends Client {
         await this.handleAuthenticateKGW(kwilSigner);
         return await this.callClient(message);
       }
-      return response;
+      return response
     }
     if (this.authMode === AuthenticationMode.PRIVATE) {
       const authBody = await this.handleAuthenticatePrivate(callBody, kwilSigner);

--- a/src/client/node/nodeKwil.ts
+++ b/src/client/node/nodeKwil.ts
@@ -20,10 +20,10 @@ export class NodeKwil extends Kwil<EnvironmentType.NODE> {
    * @param {KwilSigner} kwilSigner (optional) - KwilSigner should be passed if the action requires authentication OR if the action uses a `@caller` contextual variable. If `@caller` is used and authentication is not required, the user will not be prompted to authenticate; however, the user's identifier will be passed as the sender.
    * @returns An Object[] with the result of the action
    */
-  public async call(
+  public async call<T extends Object>(
     actionBody: CallBodyNode,
     kwilSigner?: KwilSigner
-  ): Promise<GenericResponse<Object[]>> {
+  ): Promise<GenericResponse<T[]>> {
     const setCookie = () => {
       // set the temporary cookie, if the user provided one
       if (actionBody.cookie) {

--- a/src/client/web/webKwil.ts
+++ b/src/client/web/webKwil.ts
@@ -19,10 +19,10 @@ export class WebKwil extends Kwil<EnvironmentType.BROWSER> {
    * @param {KwilSigner} kwilSigner (optional) - KwilSigner should be passed if the action requires authentication OR if the action uses a `@caller` contextual variable. If `@caller` is used and authentication is not required, the user will not be prompted to authenticate; however, the user's identifier will be passed as the sender.
    * @returns An Object[] with the result of the action or a MsgReceipt
    */
-  public async call(
+  public async call<T extends Object>(
     actionBody: CallBody,
     kwilSigner?: KwilSigner
-  ): Promise<GenericResponse<Object[]>> {
+  ): Promise<GenericResponse<T[]>> {
     return await this.baseCall(actionBody, kwilSigner);
   }
 }

--- a/testing-functions/ts_test.ts
+++ b/testing-functions/ts_test.ts
@@ -1,97 +1,93 @@
-// import { BrowserProvider, encodeRlp, Wallet } from 'ethers';
-// import { KwilSigner, NodeKwil, Utils } from '../src/index';
-import { ActionBody, PositionalParam, transformPositionalParam } from '../src/core/action';
+import { BrowserProvider, encodeRlp, Wallet } from 'ethers';
+import { KwilSigner, NodeKwil, Utils } from '../src/index';
+import { ActionBody, PositionalParams, transformPositionalParam } from '../src/core/action';
 // import { DeployBody, DropBody } from '../dist/core/database';
 // import compiledKf from './mydb.json';
 // import { TransferBody } from '../dist/funder/funding_types';
 // require('dotenv').config();
 
-// const kwil = new NodeKwil({
-//   kwilProvider: process.env.KWIL_PROVIDER as string,
-//   chainId: "",
-//   logging: true,
-// });
+const kwil = new NodeKwil({
+  kwilProvider: process.env.KWIL_PROVIDER as string,
+  chainId: "",
+  logging: true,
+});
 
-// import { numberToBytes } from '../src/utils/serial';
-// import { bytesToBase64 } from '../src/utils/base64';
+import { numberToBytes } from '../src/utils/serial';
+import { bytesToBase64 } from '../src/utils/base64';
 
-// // add window.ethereum to typeof globalthis
-// declare global {
-//   interface Window {
-//     ethereum: any;
-//   }
-// } 
+// add window.ethereum to typeof globalthis
+declare global {
+  interface Window {
+    ethereum: any;
+  }
+} 
 
-// async function buildSigner() {
-//     const wallet = new Wallet(process.env.PRIVATE_KEY as string)
-//     return new KwilSigner(wallet, await wallet.getAddress());
-// }
+async function buildSigner() {
+    const wallet = new Wallet(process.env.PRIVATE_KEY as string)
+    return new KwilSigner(wallet, await wallet.getAddress());
+}
 
-// async function main() {
-//   const signer = await buildSigner();
+async function main() {
+  const signer = await buildSigner();
 
-//   // actions
-//   const actionBody: ActionBody = {
-//     dbid: kwil.getDBID(signer.identifier, 'mydb'),
-//     name: 'add_post',
-//     namespace: 'main',
-//     inputs: [
-//       {
-//         $id: 69,
-//         $user: 'Luke',
-//         $title: 'Test Post',
-//         $body: 'This is a test post',
-//       },
-//     ],
-//     description: 'Add a post',
-//   };
+  // // actions
+  // const actionBody: ActionBody = {
+  //   dbid: kwil.getDBID(signer.identifier, 'mydb'),
+  //   name: 'add_post',
+  //   namespace: 'main',
+  //   inputs: [
+  //     {
+  //       $id: 69,
+  //       $user: 'Luke',
+  //       $title: 'Test Post',
+  //       $body: 'This is a test post',
+  //     },
+  //   ],
+  //   description: 'Add a post',
+  // };
 
-//   // execute
-//   await kwil.execute(actionBody, signer);
+  // // execute
+  // await kwil.execute(actionBody, signer);
 
-//   //call with signer
-//   // const callRes = await kwil.call(actionBody, signer);
-//   // console.log(callRes);
+  // //call with signer
+  // // const callRes = await kwil.call(actionBody, signer);
+  // // console.log(callRes);
 
-//   //call without signer
-//   // await kwil.call(actionBody);
+  // //call without signer
+  // // await kwil.call(actionBody);
 
-//   // deploy database
-//   const deployBody: DeployBody = {
-//     schema: compiledKf,
-//     description: 'My first database',
-//   };
+  // // deploy database
+  // const deployBody: DeployBody = {
+  //   schema: compiledKf,
+  //   description: 'My first database',
+  // };
 
-//   // deploy
-//   // await kwil.deploy(deployBody, signer, true);
+  // // deploy
+  // // await kwil.deploy(deployBody, signer, true);
 
-//   // drop database
-//   const dropBody: DropBody = {
-//     dbid: 'abc123',
-//     description: 'Drop this database',
-//   };
+  // // drop database
+  // const dropBody: DropBody = {
+  //   dbid: 'abc123',
+  //   description: 'Drop this database',
+  // };
 
-//   // drop
-//   // await kwil.drop(dropBody, signer);
+  // // drop
+  // // await kwil.drop(dropBody, signer);
 
-//   const funderTest: TransferBody = {
-//     to: '0xdB8C53Cd9be615934da491A7476f3f3288d98fEb',
-//     amount: BigInt(1 * 10 ** 18),
-//   };
+  // const funderTest: TransferBody = {
+  //   to: '0xdB8C53Cd9be615934da491A7476f3f3288d98fEb',
+  //   amount: BigInt(1 * 10 ** 18),
+  // };
 
-//   // transfer
-//   // const res = await kwil.funder.transfer(funderTest, signer);
-//   // console.log(res);
+  // transfer
+  // const res = await kwil.funder.transfer(funderTest, signer);
+  // console.log(res);
 
-//   // chainInfo
-//   const chainInfo = await kwil.chainInfo({
-//     disableWarning: true
-//   });
+  // chainInfo
 
-//   console.log(chainInfo);
-// }
+}
 
-// // main();
+main();
 
 // async function nilTest() {
 //   const signer = await buildSigner();
@@ -168,14 +164,3 @@ import { ActionBody, PositionalParam, transformPositionalParam } from '../src/co
 // }
 
 // // test()
-
-function positionalParamTest() {
-  const positionalParam: PositionalParam[] =[
-    ['Luke', 'hello'],
-    [1, true]
-  ]
-
-  console.log(transformPositionalParam.toNamedParams(positionalParam))
-}
-
-positionalParamTest()


### PR DESCRIPTION
The `kwil.call` and `kwil.selectQuery` methods accept generics, allowing typescript users to define the shape of the value returned from the database.

