### PR TITLE
fix: fixes bug where kwil-js would check params when using positional params

### DIFF
--- a/src/auth/auth.ts
+++ b/src/auth/auth.ts
@@ -19,7 +19,7 @@ import { CallBody, NamedParams, transformActionInput, transformPositionalParam }
 import { sha256BytesToBytes } from '../utils/crypto';
 import { UnencodedActionPayload } from '../core/payload';
 import { encodeActionCall } from '../utils/kwilEncoding';
-import { encodeActionInputs } from '../utils/parameterEncoding';
+import { encodeValueType } from '../utils/parameterEncoding';
 
 interface AuthClient {
   getAuthenticateClient(): Promise<GenericResponse<KGWAuthInfo>>;
@@ -125,7 +125,7 @@ export class Auth<T extends EnvironmentType> {
     const payload: UnencodedActionPayload<PayloadType.CALL_ACTION> = {
       dbid: actionBody.namespace,
       action: actionBody.name,
-      arguments: encodeActionInputs(actionValues),
+      arguments: encodeValueType(actionValues),
     };
 
     const encodedPayload = encodeActionCall(payload);

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -11,6 +11,23 @@ export type EntryType = Entry<ValueType> | Entry<ValueType[]>;
 
 export type NamedParams = Record<string, ValueType | ValueType[]>;
 
+export function isNamedParams(i: NamedParams[] | PositionalParams []): i is NamedParams[] {
+  let isNamedParams = false;
+
+  for (const p of i) {
+    if (isNamedParam(p)) {
+      isNamedParams = true;
+      break;
+    }
+  }
+
+  return isNamedParams;
+}      
+
+export function isNamedParam(i: NamedParams | PositionalParams): i is NamedParams {
+  return typeof i === "object" && i !== null && !Array.isArray(i);
+}
+
 export type Predicate = (k: [key: string, v: ValueType | ValueType[]]) => boolean;
 
 export type PositionalParams = ValueType[]
@@ -107,7 +124,7 @@ export interface ActionOptions {
   namespace: string;
   chainId: string;
   description: string;
-  actionInputs: NamedParams[];
+  actionInputs: NamedParams[] | PositionalParams[]
   signer?: SignerSupplier;
   identifier?: Uint8Array;
   signatureType?: AnySignatureType;

--- a/src/utils/parameterEncoding.ts
+++ b/src/utils/parameterEncoding.ts
@@ -77,7 +77,7 @@ function formatEncodedValue(val: ValueType | ValueType[]): EncodedValue {
  * @param {ValueType[]} values - An array of input values to be executed by an action.
  * @returns formatted values used for an action
  */
-export function encodeActionInputs(values: ValueType[]): EncodedValue[] {
+export function encodeValueType(values: ValueType[]): EncodedValue[] {
   return values.map((val) => formatEncodedValue(val));
 }
 

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -8,7 +8,6 @@ export type NonNil<T> = T extends Nil ? never : T;
 // allowed to be either the original type or null/undefined.
 export type Nillable<T> = T | Nil;
 export type Supplier<T> = () => T;
-export type Lazy<T> = (() => Promise<T>) | (() => T);
 export type Func<T, U> = (t: T) => U;
 export type Unary<T> = Func<T, T>;
 export type Runnable = () => void;
@@ -54,15 +53,6 @@ export namespace Promisy {
     return objects.isNil(promisy)
       ? Promise.reject<T>(new NillableError(nilError))
       : resolve(promisy as Promisy<T>);
-  }
-}
-
-export namespace Lazy {
-  export function of<T>(promisy: Promisy<T>): Lazy<Promise<T>> {
-    return (): Promise<T> => {
-      const fn = objects.requireNonNil(promisy);
-      return typeof fn === 'function' ? fn() : fn;
-    };
   }
 }
 

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -113,9 +113,9 @@ async function scratchpad() {
     $body: 'Hello World',
   };
   // executeGeneralAction(kwil, 'main', 'add_post', kwilSigner, post);
-  await executeGeneralView(kwil, 'main', 'return_caller', null, kwilSigner);
+  // await executeGeneralView(kwil, 'main', 'return_caller', null, kwilSigner);
   // await executeGeneralView(kwil, dbid, "view_must_sign", null, kwilSigner)
-  // await executePositionalView(kwil, 'mydb', 'get_post_by_title')
+  // await executePositionalView(kwil, 'main', 'get_post_by_title')
 
   // await execSql(kwil,
   //   'INSERT INTO number (id) VALUES ($id)',

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -1,96 +1,165 @@
-// TODO: Requires updating to new syntax in order to work
-describe.skip('Testing case sensitivity on test_db', () => {
-  it('placeholder test until tests are updated', () => {
-    expect(true).toBe(true);
-  });
-  //   let dbid: string;
-  //   beforeAll(async () => {
-  //     const res = await kwil.listDatabases(kwilSigner.identifier);
-  //     const dbList = res.data;
-  //     if (!dbList) {
-  //       await deployTempSchema(schema, kwilSigner);
-  //       return;
-  //     }
-  //     for (const db of dbList) {
-  //       if (db.name.startsWith('test_db_')) {
-  //         dbid = db.dbid;
-  //         return;
-  //       }
-  //     }
-  //     await deployTempSchema(schema, kwilSigner);
-  //     dbid = kwil.getDBID(kwilSigner.identifier, `test_db_${dbList.length + 1}`);
-  //   }, 10000);
-  //   afterAll(async () => {
-  //     const body: DropBody = {
-  //       dbid,
-  //     };
-  //     await kwil.drop(body, kwilSigner, true);
-  //   }, 10000);
-  //   async function buildActionInput(): Promise<ActionInput> {
-  //     return {
-  //       $username: 'Luke',
-  //       $age: 25,
-  //     };
-  //   }
-  //   it('should execute createUserTest action', async () => {
-  //     const actionInputs = await buildActionInput();
-  //     const body: ActionBody = {
-  //       name: 'createUserTest',
-  //       dbid,
-  //       inputs: [actionInputs],
-  //     };
-  //     const result = await kwil.execute(body, kwilSigner, true);
-  //     expect(result.data).toBeDefined();
-  //     expect(result.data).toMatchObject<TxReceipt>({
-  //       tx_hash: expect.any(String),
-  //     });
-  //   }, 10000);
-  //   it('should execute delete_user action', async () => {
-  //     const body: ActionBody = {
-  //       name: 'delete_user',
-  //       dbid,
-  //     };
-  //     const result = await kwil.execute(body, kwilSigner, true);
-  //     expect(result.data).toBeDefined();
-  //     expect(result.data).toMatchObject<TxReceipt>({
-  //       tx_hash: expect.any(String),
-  //     });
-  //   }, 10000);
-  //   it('should execute CREATEUSERTEST action', async () => {
-  //     const actionInputs = await buildActionInput();
-  //     const body: ActionBody = {
-  //       name: 'CREATEUSERTEST',
-  //       dbid,
-  //       inputs: [actionInputs],
-  //     };
-  //     const result = await kwil.execute(body, kwilSigner, true);
-  //     expect(result.data).toBeDefined();
-  //     expect(result.data).toMatchObject<TxReceipt>({
-  //       tx_hash: expect.any(String),
-  //     });
-  //   }, 10000);
-  //   it('should execute DELETE_USER action', async () => {
-  //     const body: ActionBody = {
-  //       name: 'DELETE_USER',
-  //       dbid,
-  //     };
-  //     const result = await kwil.execute(body, kwilSigner, true);
-  //     expect(result.data).toBeDefined();
-  //     expect(result.data).toMatchObject<TxReceipt>({
-  //       tx_hash: expect.any(String),
-  //     });
-  //   }, 10000);
-  //   it('should execute createusertest action', async () => {
-  //     const actionInputs = await buildActionInput();
-  //     const body: ActionBody = {
-  //       name: 'createusertest',
-  //       dbid,
-  //       inputs: [actionInputs],
-  //     };
-  //     const result = await kwil.execute(body, kwilSigner, true);
-  //     expect(result.data).toBeDefined();
-  //     expect(result.data).toMatchObject<TxReceipt>({
-  //       tx_hash: expect.any(String),
-  //     });
-  //   }, 10000);
-});
+import { ActionBody, CallBody } from "../../src/core/action";
+import { TxReceipt } from "../../src/core/tx";
+import { createTestSchema, isKwildPrivateOn, kwil, kwilSigner, uuidV4 } from "./setup";
+
+describe('Edge cases', () => {
+  const namespace = 'edge_cases';
+  describe('Executing Actions and calling views when default role does not have SELECT permission', () => {
+    beforeAll(async () => {
+      await createTestSchema(namespace, kwil, kwilSigner);
+      await kwil.execSql('REVOKE SELECT FROM default;', {}, kwilSigner, true);
+    }, 20000);
+    const id = uuidV4();
+
+    afterAll(async () => {
+      await kwil.execSql(`DROP NAMESPACE ${namespace};`, {}, kwilSigner, true);
+      await kwil.execSql('GRANT SELECT TO default;', {}, kwilSigner, true);
+    }, 20000);
+
+    it('should execute an action with positional params', async () => {
+      const actionBody: ActionBody = {
+        namespace,
+        name: 'add_post',
+        inputs: [[id, 'TestUser', 'Action Test', 'Testing action execution']]
+      };
+
+      const result = await kwil.execute(actionBody, kwilSigner, true);
+      expect(result.data).toMatchObject<TxReceipt>({
+        tx_hash: expect.any(String),
+      });
+    }, 10000);
+
+    it('should call a view with positional params', async () => {
+      const callBody: CallBody = {
+        namespace,
+        name: 'get_post_by_id',
+        inputs: [id]
+      }
+
+      const result = await kwil.call(callBody, kwilSigner);
+      expect(result.data).toMatchObject({
+        result: [{
+          post_title: 'Action Test',
+          post_body: 'Testing action execution'
+        }]
+      });
+    }, 10000);
+
+    it('should fail execute with named params', async () => {
+      const actionBody: ActionBody = {
+        namespace,
+        name: 'add_post',
+        inputs: [{ $id: id, $user: 'TestUser', $title: 'Action Test', $body: 'Testing action execution' }]
+      };
+
+      await expect(kwil.execute(actionBody, kwilSigner, true)).rejects.toThrow();
+    }, 10000);
+
+    (isKwildPrivateOn ? it.skip : it)('should fail call with named params', async () => {
+      const callBody: CallBody = {
+        namespace,
+        name: 'get_post_by_id',
+        inputs: { $id: id }
+      }
+
+      await expect(kwil.call(callBody, kwilSigner)).rejects.toThrow();
+    }, 10000);
+  })
+})
+
+
+// describe.skip('Testing case sensitivity on test_db', () => {
+//   it('placeholder test until tests are updated', () => {
+//     expect(true).toBe(true);
+//   });
+//   let dbid: string;
+//   beforeAll(async () => {
+//     const res = await kwil.listDatabases(kwilSigner.identifier);
+//     const dbList = res.data;
+//     if (!dbList) {
+//       await deployTempSchema(schema, kwilSigner);
+//       return;
+//     }
+//     for (const db of dbList) {
+//       if (db.name.startsWith('test_db_')) {
+//         dbid = db.dbid;
+//         return;
+//       }
+//     }
+//     await deployTempSchema(schema, kwilSigner);
+//     dbid = kwil.getDBID(kwilSigner.identifier, `test_db_${dbList.length + 1}`);
+//   }, 10000);
+//   afterAll(async () => {
+//     const body: DropBody = {
+//       dbid,
+//     };
+//     await kwil.drop(body, kwilSigner, true);
+//   }, 10000);
+//   async function buildActionInput(): Promise<ActionInput> {
+//     return {
+//       $username: 'Luke',
+//       $age: 25,
+//     };
+//   }
+//   it('should execute createUserTest action', async () => {
+//     const actionInputs = await buildActionInput();
+//     const body: ActionBody = {
+//       name: 'createUserTest',
+//       dbid,
+//       inputs: [actionInputs],
+//     };
+//     const result = await kwil.execute(body, kwilSigner, true);
+//     expect(result.data).toBeDefined();
+//     expect(result.data).toMatchObject<TxReceipt>({
+//       tx_hash: expect.any(String),
+//     });
+//   }, 10000);
+//   it('should execute delete_user action', async () => {
+//     const body: ActionBody = {
+//       name: 'delete_user',
+//       dbid,
+//     };
+//     const result = await kwil.execute(body, kwilSigner, true);
+//     expect(result.data).toBeDefined();
+//     expect(result.data).toMatchObject<TxReceipt>({
+//       tx_hash: expect.any(String),
+//     });
+//   }, 10000);
+//   it('should execute CREATEUSERTEST action', async () => {
+//     const actionInputs = await buildActionInput();
+//     const body: ActionBody = {
+//       name: 'CREATEUSERTEST',
+//       dbid,
+//       inputs: [actionInputs],
+//     };
+//     const result = await kwil.execute(body, kwilSigner, true);
+//     expect(result.data).toBeDefined();
+//     expect(result.data).toMatchObject<TxReceipt>({
+//       tx_hash: expect.any(String),
+//     });
+//   }, 10000);
+//   it('should execute DELETE_USER action', async () => {
+//     const body: ActionBody = {
+//       name: 'DELETE_USER',
+//       dbid,
+//     };
+//     const result = await kwil.execute(body, kwilSigner, true);
+//     expect(result.data).toBeDefined();
+//     expect(result.data).toMatchObject<TxReceipt>({
+//       tx_hash: expect.any(String),
+//     });
+//   }, 10000);
+//   it('should execute createusertest action', async () => {
+//     const actionInputs = await buildActionInput();
+//     const body: ActionBody = {
+//       name: 'createusertest',
+//       dbid,
+//       inputs: [actionInputs],
+//     };
+//     const result = await kwil.execute(body, kwilSigner, true);
+//     expect(result.data).toBeDefined();
+//     expect(result.data).toMatchObject<TxReceipt>({
+//       tx_hash: expect.any(String),
+//     });
+//   }, 10000);
+// });


### PR DESCRIPTION
When executing or calling an action, kwil-js calls `selectQuery` to validate and order the parameters. This commit removes the selectQuery call when the user passes positional params. This is necessary in case a kwild does not give every user the permission to execute ad-hoc selects.