### PR TITLE
fix: call with empty array

### DIFF
--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -6,7 +6,7 @@ import { ClientConfig } from './config';
 import { GenericResponse } from '../core/resreq';
 import { base64ToHex, bytesToHex, hexToBase64, hexToBytes } from '../utils/serial';
 import { TxInfoReceipt } from '../core/txQuery';
-import { CallClientResponse, Message, MsgReceipt } from '../core/message';
+import { CallClientResponse, Message } from '../core/message';
 import {
   AccountStatus,
   AuthErrorCodes,

--- a/src/client/kwil.ts
+++ b/src/client/kwil.ts
@@ -12,7 +12,7 @@ import {
   EnvironmentType,
   PayloadType,
 } from '../core/enums';
-import { ActionBody, CallBody, isNamedParam, NamedParams, PositionalParams, transformActionInput, transformPositionalParam } from '../core/action';
+import { ActionBody, CallBody, isNamedParam, NamedParams, PositionalParams, transformActionInput } from '../core/action';
 import { KwilSigner } from '../core/kwilSigner';
 import { wrap } from './intern';
 import { Funder } from '../funder/funder';

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -176,7 +176,7 @@ export const transformActionInput = {
    * @returns {boolean} - True if `inputs` is an array where every element is an ActionInput, otherwise false.
    */
   isActionInputArray(i: unknown): i is ActionInput[] {
-    return Array.isArray(i) && i.every((item) => item instanceof ActionInput);
+    return Array.isArray(i) && i.length > 0 && i.every((item) => item instanceof ActionInput);
   },
   /**
    * Transforms action inputs into entries format required by the API.

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -81,7 +81,7 @@ async function scratchpad() {
   // listDatabases(kwil)
   // ping(kwil)
   //   chainInfo(kwil)
-  // await execSingleAction(kwil, dbid, "add_post", wallet, address)
+  // await execSingleAction(kwil, 'main', "add_post", wallet, address)
   // await execSingleActionKwilSigner(kwil, dbid, "add_post", kwilSigner)
   // await select(kwil, dbid, "SELECT * FROM primitive_events")
   // bulkAction(kwil, dbid, "add_post", wallet, address)
@@ -115,7 +115,7 @@ async function scratchpad() {
   // executeGeneralAction(kwil, 'main', 'add_post', kwilSigner, post);
   // await executeGeneralView(kwil, 'main', 'return_caller', null, kwilSigner);
   // await executeGeneralView(kwil, dbid, "view_must_sign", null, kwilSigner)
-  // await executePositionalView(kwil, 'main', 'get_post_by_title')
+  await executePositionalView(kwil, 'main', 'return_all')
 
   // await execSql(kwil,
   //   'INSERT INTO number (id) VALUES ($id)',
@@ -135,9 +135,7 @@ async function executePositionalView(kwil, namespace, name) {
   const body = {
     namespace,
     name,
-    inputs: [
-      'Positional Test'
-    ]
+    inputs: [],
   };
 
   const res = await kwil.call(body);
@@ -159,7 +157,7 @@ async function executeGeneralAction(kwil, dbid, name, wallet, input) {
   const body = {
     name,
     namespace: dbid,
-    ...(input ? { inputs: [input] } : {}),
+    inputs: [{ $id:1}]
   };
 
   const res = await kwil.execute(body, wallet, true);

--- a/tests/integration/edge-cases.test.ts
+++ b/tests/integration/edge-cases.test.ts
@@ -45,6 +45,32 @@ describe('Edge cases', () => {
       });
     }, 10000);
 
+    it('should execute when an action has no params', async () => {
+      const actionBody: ActionBody = {
+        namespace,
+        name: 'add_post_no_param',
+        inputs: []
+      };
+
+      const result = await kwil.execute(actionBody, kwilSigner, true);
+      expect(result.data).toMatchObject<TxReceipt>({
+        tx_hash: expect.any(String),
+      });
+    }, 10000)
+
+    it('should call when a view has no params', async () => {
+      const callBody: CallBody = {
+        namespace,
+        name: 'read_posts_count',
+        inputs: []
+      }
+
+      const result = await kwil.call(callBody, kwilSigner);
+      expect(result.data).toMatchObject({
+        result: [{ count: "2" }]
+      });
+    }, 10000)
+
     it('should fail execute with named params', async () => {
       const actionBody: ActionBody = {
         namespace,

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -82,6 +82,10 @@ const testActions = [
     sql: `CREATE ACTION update_post($id uuid, $body text) PUBLIC { UPDATE posts SET post_body = $body WHERE id = $id; }`,
   },
   {
+    name: 'add_post_no_param',
+    sql: `CREATE ACTION add_post_no_param() PUBLIC { INSERT INTO posts (id, name, post_title, post_body) VALUES ('${uuidV4()}'::uuid, 'TestUser', 'Action Test', 'Testing action execution'); }`,
+  },
+  {
     name: 'delete_post',
     sql: `CREATE ACTION delete_post($id uuid) PUBLIC { DELETE FROM posts WHERE id = $id; }`,
   },


### PR DESCRIPTION
Fixed call bug where, when calling an action with an empty array, the SDK would make an unnecessary SELECT call to kwil-db.