### PR TITLE
feat: action input type override

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,48 @@ const res = await kwil.getAccount("account_identifier", "custom_signer_enumerato
 
 ## Advanced Usage
 
+### Overriding Action Input Types
+
+By default, kwil-js will attempt to infer the input types of the action being executed. If you wish to override this behavior (for example, to store a string that looks like a uuid in a `text` column), you can add an additional field to the `actionBody` or `CallBody` object.
+
+The examples below show how to override the input types for executing an action; however, viewing actions can also be overridden in the same way.
+
+Using named inputs:
+
+```javascript
+import { Utils } from '@kwilteam/kwil-js';
+const { DataType } = Utils;
+
+const body = {
+    namespace: 'db_namespace',
+    name: 'action_name',
+    inputs: [
+        { $name: 'input_name', $id: 'some_uuid_value'}
+    ]
+    // optional: override input types
+    types: { $name: DataType.Text, $value: DataType.Uuid }
+} 
+
+await kwil.execute(body, kwilSigner);
+```
+
+Using positional inputs:
+
+```javascript
+import { Utils } from '@kwilteam/kwil-js';
+const { DataType } = Utils;
+
+const body = {
+    namespace: 'db_namespace',
+    name: 'action_name',
+    inputs: ['some_text_value', 'some_uuid_value']
+    // optional: override input types
+    types: [DataType.Text, DataType.Uuid]
+}
+
+await kwil.execute(body, kwilSigner);
+```
+
 ### Custom Signers
 
 If you wish to sign with something other than an EtherJS signer, you may pass a callback function that accepts and returns a `Uint8Array()` and the enumerator for the signature type used.

--- a/src/client/kwil.ts
+++ b/src/client/kwil.ts
@@ -163,6 +163,7 @@ export abstract class Kwil<T extends EnvironmentType> extends Client {
       signatureType: kwilSigner.signatureType,
       nonce: actionBody.nonce,
       actionInputs: inputs,
+      types: actionBody.types,
     });
 
     const transaction = await tx.buildTx(this.authMode === AuthenticationMode.PRIVATE);
@@ -534,6 +535,7 @@ export abstract class Kwil<T extends EnvironmentType> extends Client {
       actionName: callBody.name,
       description: '',
       actionInputs: inputs,
+      types: callBody.types,
     });
 
     /**

--- a/src/core/database.ts
+++ b/src/core/database.ts
@@ -1,4 +1,3 @@
-import { QueryParams } from '../utils/types';
 import { AttributeType, IndexType, VarType } from './enums';
 import {
   CompiledKuneiform,
@@ -30,6 +29,87 @@ export interface DropBody {
   nonce?: number;
 }
 
+export interface DataInfo {
+  name: VarType;
+  is_array: boolean;
+  metadata?: Array<number> | Array<never> | null;
+}
+
+type DataInfoFactory = (p: number, s: number) => DataInfo;
+
+export namespace DataType {
+  export const Uuid: DataInfo = {
+    name: VarType.UUID,
+    is_array: false,
+    metadata: [0,0]
+  };
+  export const UuidArray: DataInfo = {
+    name: VarType.UUID,
+    is_array: true,
+    metadata: [0,0]
+  };
+  export const Text: DataInfo = {
+    name: VarType.TEXT,
+    is_array: false,
+    metadata: [0,0]
+  };
+  export const TextArray: DataInfo = {
+    name: VarType.TEXT,
+    is_array: true,
+    metadata: [0,0]
+  };
+  export const Int: DataInfo = {
+    name: VarType.INT8,
+    is_array: false,
+    metadata: [0,0]
+  };
+  export const IntArray: DataInfo = {
+    name: VarType.INT8,
+    is_array: true,
+    metadata: [0,0]
+  };
+  export const Boolean: DataInfo = {
+    name: VarType.BOOL,
+    is_array: false,
+    metadata: [0,0]
+  };
+  export const BooleanArray: DataInfo = {
+    name: VarType.BOOL,
+    is_array: true,
+    metadata: [0,0]
+  };
+  export const Numeric: DataInfoFactory = (precision: number, scale: number) => ({
+    name: VarType.NUMERIC,
+    is_array: false,
+    metadata: [precision, scale],
+  });
+  export const NumericArray: DataInfoFactory = (precision: number, scale: number) => ({
+    name: VarType.NUMERIC,
+    is_array: true,
+    metadata: [precision, scale],
+  });
+  export const Null: DataInfo = {
+    name: VarType.NULL,
+    is_array: false,
+    metadata: [0,0]
+  };
+  export const NullArray: DataInfo = {
+    name: VarType.NULL,
+    is_array: true,
+    metadata: [0,0]
+  };
+  export const Bytea: DataInfo = {
+    name: VarType.BYTEA,
+    is_array: false,
+    metadata: [0,0]
+  };
+  export const ByteaArray: DataInfo = {
+    name: VarType.BYTEA,
+    is_array: true,
+    metadata: [0,0]
+  };
+}
+
 
 
 /** DEPRECATED */
@@ -54,7 +134,7 @@ export interface Table {
 
 export interface Column {
   name: string;
-  type: DataType;
+  type: DataInfo;
   attributes: ReadonlyArray<Attribute>;
 }
 
@@ -113,15 +193,8 @@ export interface Procedure {
 
 export interface NamedType {
   name: string;
-  type: DataType;
-}
-
-export interface DataType {
-  name: VarType;
-  is_array: boolean;
-  metadata?: Array<number> | Array<never> | null;
-}
-
+  type: DataInfo;
+} 
 export interface ProcedureReturn {
   is_table: boolean;
   fields: ReadonlyArray<NamedType>;
@@ -129,6 +202,6 @@ export interface ProcedureReturn {
 
 export interface ForeignProcedure {
   name: string;
-  parameters: ReadonlyArray<DataType>;
+  parameters: ReadonlyArray<DataInfo>;
   return_types: ProcedureReturn;
 }

--- a/src/core/enums.ts
+++ b/src/core/enums.ts
@@ -7,7 +7,6 @@
 export enum VarType {
   UUID = 'uuid',
   TEXT = 'text',
-  INT = 'int',
   INT8 = 'int8',
   BOOL = 'bool',
   NUMERIC = 'numeric',

--- a/src/core/payload.ts
+++ b/src/core/payload.ts
@@ -9,7 +9,7 @@ import {
   Database,
   Procedure,
   ForeignProcedure,
-  DataType,
+  DataInfo,
   ProcedureReturn,
   NamedType,
 } from './database';
@@ -32,12 +32,12 @@ export type UnencodedActionPayload<T extends PayloadType.CALL_ACTION | PayloadTy
   };
 
 export interface EncodedValue {
-  type: DataType;
+  type: DataInfo;
   data: Uint8Array[];
 }
 
 export interface EncodedParameterValue {
-  type: DataType;
+  type: DataInfo;
   data: Base64String[];
 }
 
@@ -95,7 +95,7 @@ type CompiledColumn = Omit<Column, 'attributes' | 'type'> & {
   type: CompiledDataType;
 };
 
-export type CompiledDataType = Omit<DataType, 'name' | 'metadata'> & {
+export type CompiledDataType = Omit<DataInfo, 'name' | 'metadata'> & {
   name: string;
   metadata?: Array<number> | Array<never> | null;
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import {
   ExtensionConfig as _ExtensionConfig,
   DeployBody as _DeployBody,
   DropBody as _DropBody,
+  DataType as _DataType,
 } from './core/database';
 import { GenericResponse as _GenericResponse } from './core/resreq';
 import { TxResult as _TxResult, TxInfoReceipt as _TxInfoReceipt } from './core/txQuery';
@@ -88,6 +89,10 @@ namespace Utils {
    * @deprecated This function is deprecated and will be removed in the next major release.
    */
   export const generateDBID = _generateDBID;
+  /**
+   * `DataType` holds the different data types that can be asserted as action inputs.
+   */
+  export import DataType = _DataType;
 }
 
 export { NodeKwil, WebKwil, KwilSigner, Types, Utils, Client };

--- a/testing-functions/test.js
+++ b/testing-functions/test.js
@@ -115,7 +115,7 @@ async function scratchpad() {
   // executeGeneralAction(kwil, 'main', 'add_post', kwilSigner, post);
   // await executeGeneralView(kwil, 'main', 'return_caller', null, kwilSigner);
   // await executeGeneralView(kwil, dbid, "view_must_sign", null, kwilSigner)
-  await executePositionalView(kwil, 'main', 'return_all')
+  await executePositionalView(kwil, 'main', 'return_all')   
 
   // await execSql(kwil,
   //   'INSERT INTO number (id) VALUES ($id)',

--- a/tests/integration/setup.ts
+++ b/tests/integration/setup.ts
@@ -1,5 +1,5 @@
 import { v4 as uuidV4 } from 'uuid';
-import { KwilSigner, NodeKwil } from '../../src/index';
+import { KwilSigner, NodeKwil, Utils } from '../../src/index';
 import dotenv from 'dotenv';
 import { TxReceipt } from '../../src/core/tx';
 import { JsonRpcProvider, Wallet } from 'ethers';
@@ -152,6 +152,8 @@ async function dropTestSchema(namespace: string, kwil: any, kwilSigner: any) {
   await kwil.execSql(`DROP NAMESPACE ${namespace};`, {}, kwilSigner, true);
 }
 
+const { DataType } = Utils;
+
 export {
   kwil,
   wallet,
@@ -167,5 +169,6 @@ export {
   createGatewayActions,
   dropTestSchema,
   testActions,
-  grantAdminAccess
+  grantAdminAccess,
+  DataType
 };


### PR DESCRIPTION
Add the ability to override kwil-js inferring the data type of a passed input value. See the readme for more information.