### PR TITLE
docs: add uuid to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Make sure to use the correct version of the Kwil-JS SDK for the version of the [
 ## Installation
 
 ```bash
-npm i @kwilteam/kwil-js ethers
+npm i @kwilteam/kwil-js ethers uuid
 ```
 
 ## Initialization


### PR DESCRIPTION
While developing `sdk-js` functions, I encountered the following error related to a missing `uuid` module:
```
Error: Cannot find module 'uuid'
Require stack:
- node_modules/@kwilteam/kwil-js/dist/utils/uuid.js
...
```
This issue occurs because of the missing `uuid` package.
To avoid confusion for other developers following the README, I added `uuid` to the **Installation** section.