### PR TITLE
fix: resolve ESM build and missing Types exports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 yarn.lock
 .env
 /dist
+/dist-esm
 /pkg
 testapp/node_modules
 /.husky

--- a/package.json
+++ b/package.json
@@ -5,12 +5,14 @@
   "main": "./dist/index.js",
   "module": "./dist-esm/index.js",
   "types": "./dist/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist-esm/index.js",
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "repository": {
     "type": "git",
@@ -18,8 +20,10 @@
   },
   "files": [
     "dist/**/*.js",
-    "dist/**/*.ts",
+    "dist/**/*.d.ts",
     "dist-esm/**/*.js",
+    "dist-esm/**/*.d.ts",
+    "dist-esm/package.json",
     "!dist/**/*.map",
     "!dist/**/*.test.js",
     "!dist/**/*.test.ts",
@@ -30,14 +34,14 @@
   ],
   "scripts": {
     "clean": "rimraf dist/* dist-esm/*",
-    "build": "pnpm run clean && tsc && tsc -p tsconfig.esm.json",
+    "build": "pnpm run clean && tsc && tsc -p tsconfig.esm.json && node -e \"const fs=require('fs');fs.mkdirSync('dist-esm',{recursive:true});fs.writeFileSync('dist-esm/package.json','{\\\"type\\\":\\\"module\\\"}\\n');\"",
+    "type-check:esm": "tsc -p tsconfig.esm.json --noEmit",
     "commit": "git add . && git-cz",
     "prepare": "husky install",
     "release": "standard-version",
-    "pack_build": "pnpm run clean && tsc --outDir ./dist --sourceMap false --declarationDir ./dist",
-    "pack_pre": "copyfiles package.json README.md dist && rimraf ./kwil*.tgz",
+    "pack_pre": "rimraf ./kwil*.tgz",
     "pack_post": "copyfiles ./kwil*.tgz ./pkg && rimraf ./kwil*.tgz",
-    "pack": "pnpm run pack_build && pnpm run pack_pre && pnpm --prefix ./dist pack && pnpm run pack_post",
+    "pack": "pnpm run build && pnpm run pack_pre && pnpm pack && pnpm run pack_post",
     "integration": "jest --runInBand --testPathPattern=tests/integration --testTimeout=30000",
     "test": "jest",
     "lint": "eslint src --ext .ts,.tsx",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,15 @@
   "version": "0.9.5",
   "description": "",
   "main": "./dist/index.js",
+  "module": "./dist-esm/index.js",
   "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist-esm/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/trufnetwork/kwil-js.git"
@@ -11,16 +19,18 @@
   "files": [
     "dist/**/*.js",
     "dist/**/*.ts",
+    "dist-esm/**/*.js",
     "!dist/**/*.map",
     "!dist/**/*.test.js",
     "!dist/**/*.test.ts",
+    "!dist-esm/**/*.map",
     "CHANGELOG.md",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "clean": "rimraf dist/*",
-    "build": "pnpm run clean && tsc",
+    "clean": "rimraf dist/* dist-esm/*",
+    "build": "pnpm run clean && tsc && tsc -p tsconfig.esm.json",
     "commit": "git add . && git-cz",
     "prepare": "husky install",
     "release": "standard-version",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trufnetwork/kwil-js",
-  "version": "0.9.5",
+  "version": "0.9.7",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist-esm/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,9 @@ import Client from './api_client/client';
 import { AuthSuccess as _AuthSuccess, LogoutResponse as _LogoutResponse} from './core/auth';
 import { AuthBody as _AuthBody } from './core/signature';
 import { TransferBody as _TransferBody } from './funder/funding_types';
-import { Config as _Config } from './api_client/config';
+import { Config as _Config, KwilConfig as _KwilConfig } from './api_client/config';
+import { EthSigner as _EthSigner } from './core/signature';
+import { Kwil as _Kwil } from './client/kwil';
 
 namespace Types {
   export type TxReceipt = _TxReceipt;
@@ -57,6 +59,9 @@ namespace Types {
   export type LogoutResponse<T extends EnvironmentType> = _LogoutResponse<T>;
   export type TransferBody = _TransferBody;
   export type Config = _Config
+  export type KwilConfig = _KwilConfig
+  export type EthSigner = _EthSigner
+  export type Kwil<T extends EnvironmentType = EnvironmentType> = _Kwil<T>
   export type NamedParams = _NamedParams
   export type PositionalParams = _PositionalParams
   export type ValueType = _ValueType

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,4 +95,4 @@ namespace Utils {
   export import DataType = _DataType;
 }
 
-export { NodeKwil, WebKwil, KwilSigner, Types, Utils, Client };
+export { NodeKwil, WebKwil, KwilSigner, Types, Utils, Client, EnvironmentType };

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -2,8 +2,8 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "target": "ES2021",
-    "module": "ES2020",
-    "moduleResolution": "node",
+    "module": "ESNext",
+    "moduleResolution": "NodeNext",
     "outDir": "./dist-esm",
     "rootDir": "./src",
     "lib": ["DOM", "DOM.Iterable", "ES2020"],

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "target": "ES2020",
+    "moduleResolution": "node",
+    "outDir": "./dist-esm",
+    "declaration": false,
+    "declarationDir": null,
+    "declarationMap": false,
+    "sourceMap": false
+  }
+}

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -1,13 +1,17 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "target": "ES2021",
     "module": "ES2020",
-    "target": "ES2020",
     "moduleResolution": "node",
     "outDir": "./dist-esm",
+    "rootDir": "./src",
+    "lib": ["DOM", "DOM.Iterable", "ES2020"],
     "declaration": false,
     "declarationDir": null,
     "declarationMap": false,
-    "sourceMap": false
-  }
+    "sourceMap": false,
+    "resolveJsonModule": false
+  },
+  "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/truf-network/issues/1205
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded TypeScript API by exporting additional types (KwilConfig, EthSigner, Kwil) to improve IDE hints and type safety. No runtime changes.

- Chores
  - Bumped package version to 0.9.7.
  - Updated ESM build settings (ESNext modules with NodeNext resolution) to improve compatibility with modern bundlers and ESM tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->