### PR TITLE
chore: prevent double enconding already hexadecimal tx_hash

### DIFF
--- a/src/api_client/client.ts
+++ b/src/api_client/client.ts
@@ -266,8 +266,11 @@ export default class Client extends Api {
   }
 
   protected async txInfoClient(tx_hash: string): Promise<GenericResponse<TxInfoReceipt>> {
+    // NOTE: The kwil node expects transaction hashes in hexadecimal format.
+    // Send tx_hash as-is without converting to base64, which would cause
+    // "invalid hash length: expected 64, got 44" errors from the node.
     const body = this.buildJsonRpcRequest<TxQueryRequest>(JSONRPCMethod.METHOD_TX_QUERY, {
-      tx_hash: hexToBase64(tx_hash),
+      tx_hash: tx_hash,
     });
 
     const res = await super.post<JsonRPCResponse<TxQueryResponse>>(`/rpc/v1`, body);

--- a/src/utils/serial.ts
+++ b/src/utils/serial.ts
@@ -114,8 +114,10 @@ function isValidHex(str: string): boolean {
 }
 
 export function base64ToHex(base64: string): HexString {
-    // If the input is already a valid hex string, return it as-is
-    // This handles cases where the node returns hex instead of base64
+    // NOTE: The kwil node returns transaction hashes as hexadecimal strings, not base64.
+    // To maintain backward compatibility, we check if the input
+    // is already hex and return it as-is. This prevents double-encoding (hex→base64→hex)
+    // which previously corrupted 64-char hashes into 96-char garbage values.
     if (isValidHex(base64)) {
         // Strip 0x prefix if present to return consistent format
         return (base64.startsWith('0x') ? base64.slice(2) : base64) as HexString;

--- a/src/utils/serial.ts
+++ b/src/utils/serial.ts
@@ -101,7 +101,27 @@ export function hexToBytes(hex: string): Uint8Array {
     return bytes;
 }
 
+/**
+ * Helper function to check if a string is valid hexadecimal
+ */
+function isValidHex(str: string): boolean {
+    // Strip 0x prefix if present
+    const hexStr = str.startsWith('0x') ? str.slice(2) : str;
+
+    // Check if string only contains hex characters (0-9, a-f, A-F)
+    // and has even length (since each byte = 2 hex chars)
+    return /^[0-9a-fA-F]+$/.test(hexStr) && hexStr.length > 0 && hexStr.length % 2 === 0;
+}
+
 export function base64ToHex(base64: string): HexString {
+    // If the input is already a valid hex string, return it as-is
+    // This handles cases where the node returns hex instead of base64
+    if (isValidHex(base64)) {
+        // Strip 0x prefix if present to return consistent format
+        return (base64.startsWith('0x') ? base64.slice(2) : base64) as HexString;
+    }
+
+    // Otherwise, treat it as base64 and convert to hex
     return bytesToHex(base64ToBytes(base64));
 }
 


### PR DESCRIPTION
Fixes critical transaction hash encoding bugs that prevented correct hash handling in broadcast and query operations.

**Changes**:
- Modified `base64ToHex()` utility to auto-detect hexadecimal input and return as-is, eliminating unnecessary double-encoding

**Impact**:
- Transaction hashes now correctly formatted as 64-character hexadecimal strings
- Transaction queries no longer fail with "invalid hash length" errors

**Business Value**:
Enables reliable transaction tracking and attestation workflows by ensuring transaction identifiers are correctly formatted throughout the system.

resolves: https://github.com/trufnetwork/truf-network/issues/1274

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of hex and base64 inputs for faster processing and more reliable validation when hex is provided.
* **Bug Fixes**
  * Tx identifiers are now sent using the expected hexadecimal format, reducing encoding-related errors when communicating with nodes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->