### PR TITLE
fix: encode empty Uint8Array as NULL for BYTEA parameters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@trufnetwork/kwil-js",
-  "version": "0.9.9",
+  "version": "0.9.10",
   "description": "",
   "main": "./dist/index.js",
   "module": "./dist-esm/index.mjs",

--- a/src/utils/kwilEncoding.ts
+++ b/src/utils/kwilEncoding.ts
@@ -220,6 +220,11 @@ export function encodeValue(value: ValueType, o?: VarType): Uint8Array {
 
   // handle Uint8Array case
   if (value instanceof Uint8Array) {
+    // Treat empty Uint8Array as NULL for BYTEA type
+    // This allows JavaScript code to pass new Uint8Array(0) to represent BYTEA NULL
+    if (value.length === 0) {
+      return encodeNull();
+    }
     return encodeNotNull(value);
   }
 

--- a/src/utils/kwilEncoding.ts
+++ b/src/utils/kwilEncoding.ts
@@ -269,7 +269,12 @@ function overrideValue(v: ValueType, o: VarType): Uint8Array {
     case VarType.UUID:
       return encodeNotNull(convertUuidToBytes(v as string));
     case VarType.BYTEA:
-      return encodeNotNull(v as Uint8Array);
+      // Treat empty Uint8Array as NULL for consistency with normal encoding path
+      const byteaValue = v as Uint8Array;
+      if (byteaValue.length === 0) {
+        return encodeNull();
+      }
+      return encodeNotNull(byteaValue);
     default:
       throw new Error('invalid scalar value');
   }

--- a/src/utils/kwilEncoding.ts
+++ b/src/utils/kwilEncoding.ts
@@ -268,13 +268,14 @@ function overrideValue(v: ValueType, o: VarType): Uint8Array {
       return encodeNotNull(stringToBytes(v.toString()));
     case VarType.UUID:
       return encodeNotNull(convertUuidToBytes(v as string));
-    case VarType.BYTEA:
+    case VarType.BYTEA: {
       // Treat empty Uint8Array as NULL for consistency with normal encoding path
       const byteaValue = v as Uint8Array;
       if (byteaValue.length === 0) {
         return encodeNull();
       }
       return encodeNotNull(byteaValue);
+    }
     default:
       throw new Error('invalid scalar value');
   }


### PR DESCRIPTION
Problem:
When calling view actions with optional BYTEA parameters, there was no way to pass SQL NULL from JavaScript. Passing JavaScript `null` resulted in VarType.NULL (generic null), which didn't work correctly with SQL `IS NULL` checks for BYTEA columns.

Root Cause:
In kwilEncoding.ts, empty Uint8Array(0) was always encoded as "not null empty bytea" using encodeNotNull(), which produces '\x' in PostgreSQL. This is semantically different from NULL and causes SQL `IS NULL` checks to fail.

Solution:
Treat empty Uint8Array(0) as BYTEA NULL by encoding it with encodeNull() instead of encodeNotNull(). This provides a JavaScript-idiomatic way to represent BYTEA NULL while maintaining backward compatibility.

Changes:
- src/utils/kwilEncoding.ts (encodeValue function):
  * Add length check for Uint8Array before encoding
  * Empty Uint8Array (length === 0) → encodeNull()
  * Non-empty Uint8Array (length > 0) → encodeNotNull(value)

resolves: https://github.com/trufnetwork/kwil-js/issues/145

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Empty byte arrays now encode as NULL rather than non-null, ensuring consistent BYTEA handling across code paths; non-empty byte arrays and other types (e.g., UUID) continue to encode unchanged.

* **Chores**
  * Package version bumped to 0.9.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->