### PR TITLE
chore: add Node.js admin JSON-RPC client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ testapp/node_modules
 # Act testing files
 .secrets.act
 .act-events
+CLAUDE.md

--- a/src/api_client/admin_client.ts
+++ b/src/api_client/admin_client.ts
@@ -1,0 +1,203 @@
+import Axios, { AxiosInstance, AxiosRequestConfig } from 'axios';
+
+/**
+ * Configuration for the admin JSON-RPC client.
+ */
+export interface AdminClientConfig {
+  /** URL of the admin JSON-RPC server (e.g., "http://127.0.0.1:8485") */
+  adminProvider: string;
+  /** Request timeout in milliseconds (default: 10000) */
+  timeout?: number;
+  /** Enable request/response logging */
+  logging?: boolean;
+  /** Custom logger function */
+  logger?: (msg: string) => any;
+  /**
+   * Basic auth credentials for the admin server.
+   * Used when the admin server is configured with password authentication.
+   */
+  auth?: {
+    username: string;
+    password: string;
+  };
+  /**
+   * Additional Axios request configuration.
+   * Use this for advanced scenarios such as mTLS:
+   *
+   * ```ts
+   * import https from 'https';
+   * const client = new AdminClient({
+   *   adminProvider: 'https://node.example.com:8485',
+   *   axiosConfig: {
+   *     httpsAgent: new https.Agent({ ca, cert, key }),
+   *   },
+   * });
+   * ```
+   */
+  axiosConfig?: AxiosRequestConfig;
+}
+
+interface JsonRpcRequest {
+  jsonrpc: '2.0';
+  id: number;
+  method: string;
+  params: unknown;
+}
+
+interface JsonRpcResponse<T> {
+  jsonrpc: string;
+  id: number;
+  result?: T;
+  error?: {
+    code?: number;
+    message?: string;
+    data?: unknown;
+  };
+}
+
+/**
+ * Generic admin JSON-RPC client for the kwil-db admin server.
+ *
+ * This client is **Node.js only** — admin operations should never run in
+ * a browser. It provides a single `callMethod()` that sends a JSON-RPC 2.0
+ * request to the admin port and returns the typed result.
+ *
+ * No domain-specific methods are defined here — this is pure transport.
+ * TN-specific local-stream methods live in sdk-js's `LocalActions`.
+ *
+ * @example Basic auth
+ * ```ts
+ * const admin = new AdminClient({
+ *   adminProvider: 'http://127.0.0.1:8485',
+ *   auth: { username: 'admin', password: 'secret' },
+ * });
+ * const result = await admin.callMethod<StatusResult>('admin.status', {});
+ * ```
+ *
+ * @example mTLS
+ * ```ts
+ * import https from 'https';
+ * const admin = new AdminClient({
+ *   adminProvider: 'https://node.example.com:8485',
+ *   axiosConfig: {
+ *     httpsAgent: new https.Agent({ ca, cert, key }),
+ *   },
+ * });
+ * ```
+ */
+export class AdminClient {
+  private readonly adminProvider: string;
+  private readonly timeout: number;
+  private readonly logging: boolean;
+  private readonly logger: (msg: string) => any;
+  private readonly authConfig?: { username: string; password: string };
+  private readonly extraAxiosConfig?: AxiosRequestConfig;
+  private jsonRpcId: number = 1;
+
+  constructor(config: AdminClientConfig) {
+    if (typeof window !== 'undefined') {
+      throw new Error(
+        'AdminClient is only available in Node.js environments. ' +
+          'The admin API should not be exposed to browsers.'
+      );
+    }
+
+    if (!config.adminProvider) {
+      throw new Error('No admin provider URL provided in AdminClientConfig.');
+    }
+
+    this.adminProvider = config.adminProvider;
+    this.timeout = config.timeout ?? 10000;
+    this.logging = config.logging ?? false;
+    this.logger = config.logger ?? console.log;
+    this.authConfig = config.auth;
+    this.extraAxiosConfig = config.axiosConfig;
+  }
+
+  /**
+   * Call a JSON-RPC method on the admin server.
+   *
+   * @param method - The JSON-RPC method name (e.g., "admin.status", "local.create_stream")
+   * @param params - The parameters to send with the request
+   * @returns The result from the JSON-RPC response, typed as `T`
+   * @throws Error if the server returns a non-200 status, a JSON-RPC error, or no result
+   */
+  async callMethod<T = unknown>(method: string, params: unknown): Promise<T> {
+    const body: JsonRpcRequest = {
+      jsonrpc: '2.0',
+      id: this.jsonRpcId++,
+      method,
+      params: params ?? {},
+    };
+
+    const perRequestConfig: AxiosRequestConfig = { ...this.extraAxiosConfig };
+
+    if (this.authConfig) {
+      perRequestConfig.auth = {
+        username: this.authConfig.username,
+        password: this.authConfig.password,
+      };
+    }
+
+    const instance = this.createInstance();
+
+    let res;
+    try {
+      res = await instance.post<JsonRpcResponse<T>>('/rpc/v1', body, perRequestConfig);
+    } catch (error: any) {
+      if (error.response && error.response.status) {
+        res = error.response;
+      } else {
+        throw error;
+      }
+    }
+
+    if (res.status !== 200) {
+      throw new Error(
+        JSON.stringify(res.data) || `Admin RPC request failed with status ${res.status}`
+      );
+    }
+
+    if (!res.data) {
+      throw new Error('Failed to parse admin RPC response.');
+    }
+
+    if (res.data.error) {
+      const data = res.data.error.data
+        ? `, data: ${JSON.stringify(res.data.error.data)}`
+        : '';
+      throw new Error(
+        `Admin RPC error: code: ${res.data.error.code}, message: ${res.data.error.message}` +
+          data
+      );
+    }
+
+    if (res.data.jsonrpc !== '2.0') {
+      throw new Error(JSON.stringify(res.data) || 'Invalid JSON-RPC response from admin server.');
+    }
+
+    // Allow null/undefined results — some methods (like create_stream) return empty
+    return res.data.result as T;
+  }
+
+  private createInstance(): AxiosInstance {
+    const instance = Axios.create({
+      baseURL: this.adminProvider,
+      timeout: this.timeout,
+    });
+
+    if (this.logging) {
+      instance.interceptors.request.use((request) => {
+        this.logger(`Admin RPC Request: ${request.baseURL}${request.url}`);
+        return request;
+      });
+
+      instance.interceptors.response.use((response) => {
+        this.logger(`Admin RPC Response: ${response.config.url} - ${response.status}`);
+        return response;
+      });
+    }
+
+    return instance;
+  }
+}

--- a/src/api_client/admin_client.ts
+++ b/src/api_client/admin_client.ts
@@ -102,11 +102,16 @@ export class AdminClient {
       );
     }
 
-    if (!config.adminProvider) {
+    if (!config) {
+      throw new Error('AdminClientConfig is required.');
+    }
+
+    const trimmedProvider = (config.adminProvider || '').trim();
+    if (!trimmedProvider) {
       throw new Error('No admin provider URL provided in AdminClientConfig.');
     }
 
-    this.adminProvider = config.adminProvider;
+    this.adminProvider = trimmedProvider;
     this.timeout = config.timeout ?? 10000;
     this.logging = config.logging ?? false;
     this.logger = config.logger ?? console.log;

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,8 @@ import { KwilSigner } from './core/kwilSigner';
 import { EnvironmentType } from './core/enums';
 import { QueryParams as _QueryParams, ValueType as _ValueType } from './utils/types';
 import Client from './api_client/client';
+import { AdminClient } from './api_client/admin_client';
+import { AdminClientConfig as _AdminClientConfig } from './api_client/admin_client';
 import { AuthSuccess as _AuthSuccess, LogoutResponse as _LogoutResponse} from './core/auth';
 import { AuthBody as _AuthBody } from './core/signature';
 import { TransferBody as _TransferBody } from './funder/funding_types';
@@ -69,6 +71,7 @@ namespace Types {
   export type PositionalParams = _PositionalParams
   export type ValueType = _ValueType
   export type EncodedValue = _EncodedValue
+  export type AdminClientConfig = _AdminClientConfig
 
   // below are deprecated and can be removed on next release (kwil-js v0.10)
   export type Database = _Database;
@@ -116,4 +119,4 @@ namespace Utils {
   export const encodeEncodedValue = _encodeEncodedValue;
 }
 
-export { NodeKwil, WebKwil, KwilSigner, Types, Utils, Client, EnvironmentType };
+export { NodeKwil, WebKwil, KwilSigner, Types, Utils, Client, AdminClient, EnvironmentType };

--- a/tests/unitTests/api_client/admin_client.test.ts
+++ b/tests/unitTests/api_client/admin_client.test.ts
@@ -17,15 +17,44 @@ describe('AdminClient', () => {
       expect(client).toBeInstanceOf(AdminClient);
     });
 
+    it('should throw if config is undefined', () => {
+      expect(() => new AdminClient(undefined as any)).toThrow('AdminClientConfig is required');
+    });
+
+    it('should throw if config is null', () => {
+      expect(() => new AdminClient(null as any)).toThrow('AdminClientConfig is required');
+    });
+
     it('should throw if adminProvider is empty', () => {
       expect(() => new AdminClient({ adminProvider: '' })).toThrow(
         'No admin provider URL provided'
       );
     });
 
-    it('should use default timeout of 10000ms', () => {
+    it('should throw if adminProvider is whitespace-only', () => {
+      expect(() => new AdminClient({ adminProvider: '   ' })).toThrow(
+        'No admin provider URL provided'
+      );
+    });
+
+    it('should trim whitespace from adminProvider', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: { jsonrpc: '2.0', id: 1, result: 'ok' },
+      });
+
+      const client = new AdminClient({ adminProvider: '  http://localhost:8485  ' });
+      await client.callMethod('admin.status', {});
+
+      // Axios.create should receive the trimmed URL as baseURL
+      const Axios = require('axios');
+      expect(Axios.create).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'http://localhost:8485' })
+      );
+    });
+
+    it('should construct with default options when only adminProvider is given', () => {
       const client = new AdminClient({ adminProvider: 'http://localhost:8485' });
-      // We can't easily inspect private fields, but the constructor should not throw
       expect(client).toBeInstanceOf(AdminClient);
     });
   });

--- a/tests/unitTests/api_client/admin_client.test.ts
+++ b/tests/unitTests/api_client/admin_client.test.ts
@@ -1,0 +1,243 @@
+import { postMock } from './api-utils';
+import { AdminClient, AdminClientConfig } from '../../../src/api_client/admin_client';
+
+describe('AdminClient', () => {
+  const defaultConfig: AdminClientConfig = {
+    adminProvider: 'http://127.0.0.1:8485',
+    timeout: 10000,
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('constructor', () => {
+    it('should create an instance with valid config', () => {
+      const client = new AdminClient(defaultConfig);
+      expect(client).toBeInstanceOf(AdminClient);
+    });
+
+    it('should throw if adminProvider is empty', () => {
+      expect(() => new AdminClient({ adminProvider: '' })).toThrow(
+        'No admin provider URL provided'
+      );
+    });
+
+    it('should use default timeout of 10000ms', () => {
+      const client = new AdminClient({ adminProvider: 'http://localhost:8485' });
+      // We can't easily inspect private fields, but the constructor should not throw
+      expect(client).toBeInstanceOf(AdminClient);
+    });
+  });
+
+  describe('callMethod', () => {
+    it('should send a JSON-RPC 2.0 request and return the result', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: {
+          jsonrpc: '2.0',
+          id: 1,
+          result: { healthy: true },
+        },
+      });
+
+      const client = new AdminClient(defaultConfig);
+      const result = await client.callMethod<{ healthy: boolean }>('admin.status', {});
+
+      expect(result).toEqual({ healthy: true });
+      expect(postMock).toHaveBeenCalledWith(
+        '/rpc/v1',
+        expect.objectContaining({
+          jsonrpc: '2.0',
+          method: 'admin.status',
+          params: {},
+        }),
+        expect.any(Object)
+      );
+    });
+
+    it('should increment JSON-RPC id on each call', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: { jsonrpc: '2.0', id: 1, result: 'ok' },
+      });
+
+      const client = new AdminClient(defaultConfig);
+
+      await client.callMethod('method1', {});
+      await client.callMethod('method2', {});
+
+      const firstCall = postMock.mock.calls[0][1];
+      const secondCall = postMock.mock.calls[1][1];
+
+      expect(secondCall.id).toBe(firstCall.id + 1);
+    });
+
+    it('should pass null params as empty object', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: { jsonrpc: '2.0', id: 1, result: [] },
+      });
+
+      const client = new AdminClient(defaultConfig);
+      await client.callMethod('local.list_streams', null);
+
+      expect(postMock).toHaveBeenCalledWith(
+        '/rpc/v1',
+        expect.objectContaining({ params: {} }),
+        expect.any(Object)
+      );
+    });
+
+    it('should pass structured params through unchanged', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: { jsonrpc: '2.0', id: 1, result: {} },
+      });
+
+      const params = { stream_id: 'st1234567890abcdef1234567890ab', stream_type: 'primitive' };
+      const client = new AdminClient(defaultConfig);
+      await client.callMethod('local.create_stream', params);
+
+      expect(postMock).toHaveBeenCalledWith(
+        '/rpc/v1',
+        expect.objectContaining({ params }),
+        expect.any(Object)
+      );
+    });
+
+    it('should throw on JSON-RPC error response', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: {
+          jsonrpc: '2.0',
+          id: 1,
+          error: {
+            code: -32602,
+            message: 'stream not found',
+          },
+        },
+      });
+
+      const client = new AdminClient(defaultConfig);
+      await expect(client.callMethod('local.get_record', {})).rejects.toThrow(
+        'Admin RPC error: code: -32602, message: stream not found'
+      );
+    });
+
+    it('should include error data in the thrown message', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: {
+          jsonrpc: '2.0',
+          id: 1,
+          error: {
+            code: -32603,
+            message: 'internal error',
+            data: { detail: 'connection refused' },
+          },
+        },
+      });
+
+      const client = new AdminClient(defaultConfig);
+      await expect(client.callMethod('admin.status', {})).rejects.toThrow(
+        'data: {"detail":"connection refused"}'
+      );
+    });
+
+    it('should throw on non-200 HTTP status', async () => {
+      postMock.mockImplementation(() => {
+        const error: any = new Error('Request failed');
+        error.response = {
+          status: 500,
+          data: { message: 'Internal Server Error' },
+        };
+        throw error;
+      });
+
+      const client = new AdminClient(defaultConfig);
+      await expect(client.callMethod('admin.status', {})).rejects.toThrow(
+        'Internal Server Error'
+      );
+    });
+
+    it('should throw on network error (no response)', async () => {
+      postMock.mockRejectedValue(new Error('ECONNREFUSED'));
+
+      const client = new AdminClient(defaultConfig);
+      await expect(client.callMethod('admin.status', {})).rejects.toThrow('ECONNREFUSED');
+    });
+
+    it('should return null/undefined results without throwing', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: {
+          jsonrpc: '2.0',
+          id: 1,
+          result: null,
+        },
+      });
+
+      const client = new AdminClient(defaultConfig);
+      const result = await client.callMethod('local.create_stream', {});
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('basic auth', () => {
+    it('should pass auth config in the request', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: { jsonrpc: '2.0', id: 1, result: 'ok' },
+      });
+
+      const client = new AdminClient({
+        ...defaultConfig,
+        auth: { username: 'admin', password: 'secret' },
+      });
+
+      await client.callMethod('admin.status', {});
+
+      expect(postMock).toHaveBeenCalledWith(
+        '/rpc/v1',
+        expect.any(Object),
+        expect.objectContaining({
+          auth: { username: 'admin', password: 'secret' },
+        })
+      );
+    });
+
+    it('should not include auth when not configured', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: { jsonrpc: '2.0', id: 1, result: 'ok' },
+      });
+
+      const client = new AdminClient(defaultConfig);
+      await client.callMethod('admin.status', {});
+
+      const passedConfig = postMock.mock.calls[0][2];
+      expect(passedConfig.auth).toBeUndefined();
+    });
+  });
+
+  describe('extra axios config', () => {
+    it('should merge extra axios config into the request', async () => {
+      postMock.mockResolvedValue({
+        status: 200,
+        data: { jsonrpc: '2.0', id: 1, result: 'ok' },
+      });
+
+      const mockAgent = { keepAlive: true };
+      const client = new AdminClient({
+        ...defaultConfig,
+        axiosConfig: { httpsAgent: mockAgent },
+      });
+
+      await client.callMethod('admin.status', {});
+
+      const passedConfig = postMock.mock.calls[0][2];
+      expect(passedConfig.httpsAgent).toBe(mockAgent);
+    });
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,6 +22,7 @@
     "src/funder/*.ts",
     "src/client/kwil.ts",
     "src/api_client/config.ts",
+    "src/api_client/admin_client.ts",
     "src/utils/*.ts",
   ]
 }


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added AdminClient for making JSON-RPC requests to admin endpoints with built-in support for authentication credentials, custom request timeout configuration, and optional detailed request/response logging.

* **Tests**
  * Added comprehensive unit test suite for AdminClient covering constructor validation, JSON-RPC request/response handling, authentication, and various error scenarios.

* **Chores**
  * Updated TypeScript build configuration and repository gitignore file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->