### PR TITLE
feat: submit agent-wallet transactions

### DIFF
--- a/src/client/kwil.ts
+++ b/src/client/kwil.ts
@@ -12,7 +12,7 @@ import {
   EnvironmentType,
   PayloadType,
 } from '../core/enums';
-import { ActionBody, CallBody, isNamedParam, NamedParams, PositionalParams, transformActionInput } from '../core/action';
+import { ActionBody, CallBody, isNamedParam, MAAExecBody, NamedParams, PositionalParams, transformActionInput } from '../core/action';
 import { KwilSigner } from '../core/kwilSigner';
 import { wrap } from './intern';
 import { Funder } from '../funder/funder';
@@ -21,14 +21,14 @@ import { Action } from '../transaction/action';
 import { Message, MsgReceipt } from '../core/message';
 import { AuthBody } from '../core/signature';
 import { SelectQueryRequest } from '../core/jsonrpc';
-import { encodeParameters, encodeRawStatementParameters } from '../utils/parameterEncoding';
+import { encodeParameters, encodeRawStatementParameters, formatEncodedValue } from '../utils/parameterEncoding';
 import { generateDBID } from '../utils/dbid';
 import { Base64String, QueryParams } from '../utils/types';
 import { PayloadTx } from '../transaction/payloadTx';
-import { RawStatementPayload } from '../core/payload';
+import { MAAExecPayload, RawStatementPayload } from '../core/payload';
 import { resolveNamespace, validateNamespace } from '../utils/namespace';
 import { inferKeyType } from '../utils/keys';
-import { bytesToHex } from '../utils/serial';
+import { bytesToHex, hexToBytes } from '../utils/serial';
 import { LRUCache } from 'lru-cache';
 
 /**
@@ -308,6 +308,66 @@ export abstract class Kwil<T extends EnvironmentType> extends Client {
       identifier: signer.identifier,
       signer: signer.signer,
       signatureType: signer.signatureType,
+    }).buildTx();
+
+    return await this.broadcastClient(
+      transaction,
+      synchronous ? BroadcastSyncType.COMMIT : BroadcastSyncType.SYNC
+    );
+  }
+
+  /**
+   * Runs a single inner action AS an agent wallet — a `maa_exec` transaction (Modular Agent
+   * Addresses). The signer must be the wallet's restricted agent or its unrestricted owner; the node
+   * looks up the rule bound to the wallet, enforces the allow-list for the signer's role, and
+   * re-enters the engine with `@caller` rewritten to the wallet. This is a distinct transaction
+   * payload, not an action call, so it does not validate against the action schema before broadcast.
+   *
+   * @param maaExecBody - The agent-wallet address, the inner action, and its positional inputs.
+   * @param signer - The component key (restricted agent or unrestricted owner) that signs the tx.
+   * @param synchronous - When true, waits for the tx to be included in a block before resolving.
+   * @returns Promise resolving to the transaction receipt.
+   */
+  public async maaExec(
+    maaExecBody: MAAExecBody,
+    signer: KwilSigner,
+    synchronous?: boolean
+  ): Promise<GenericResponse<TxReceipt>> {
+    if (!maaExecBody.action) {
+      throw new Error('action is required in maaExecBody');
+    }
+
+    const maaAddress =
+      typeof maaExecBody.maaAddress === 'string'
+        ? hexToBytes(maaExecBody.maaAddress)
+        : maaExecBody.maaAddress;
+
+    if (maaAddress.length !== 20) {
+      throw new Error(`maaAddress must be 20 bytes, got ${maaAddress.length}`);
+    }
+
+    const inputs = maaExecBody.inputs ?? [];
+    const types = maaExecBody.types;
+    const encodedArguments = inputs.map((value, i) => formatEncodedValue(value, types?.[i]));
+
+    const payload: MAAExecPayload = {
+      maaAddress,
+      // mirror the node's empty-namespace normalization
+      namespace: maaExecBody.namespace || 'main',
+      action: maaExecBody.action,
+      arguments: encodedArguments,
+    };
+
+    const transaction = await PayloadTx.createTx(this, {
+      chainId: this.chainId,
+      description:
+        maaExecBody.description || `Executing agent-wallet action: ${maaExecBody.action}`,
+      payload,
+      payloadType: PayloadType.MAA_EXEC,
+      identifier: signer.identifier,
+      signer: signer.signer,
+      signatureType: signer.signatureType,
+      nonce: maaExecBody.nonce,
     }).buildTx();
 
     return await this.broadcastClient(

--- a/src/core/action.ts
+++ b/src/core/action.ts
@@ -158,6 +158,46 @@ export interface ActionBody {
 }
 
 /**
+ * MAAExecBody is the interface for running an inner action AS an agent wallet with the
+ * `kwil.maaExec()` method (a `maa_exec` transaction). The outer signer is the wallet's restricted
+ * agent or unrestricted owner; the node rewrites `@caller` to the wallet after checking the rule's
+ * role and allow-list.
+ */
+export interface MAAExecBody {
+  /**
+   * maaAddress is the 20-byte agent-wallet (MAA) address whose identity the inner action assumes,
+   * given as a 0x-hex string or raw bytes.
+   */
+  maaAddress: string | Uint8Array;
+  /**
+   * action is the name of the inner action to run as the wallet.
+   */
+  action: string;
+  /**
+   * inputs are the positional arguments for the inner action (a single call).
+   */
+  inputs?: PositionalParams;
+  /**
+   * types optionally pins the data type of each positional input (by position). Unlike `execute`,
+   * `maa_exec` is not validated against the action schema before broadcast, so pin a type here for
+   * any argument whose JS value would otherwise infer the wrong kwil type (e.g. numeric/uuid/bytea).
+   */
+  types?: DataInfo[];
+  /**
+   * namespace is the namespace of the inner action. Defaults to "main".
+   */
+  namespace?: string;
+  /**
+   * description is an optional description shown in the signature message.
+   */
+  description?: string;
+  /**
+   * nonce is an optional nonce value for the transaction.
+   */
+  nonce?: number;
+}
+
+/**
  * CallBody is the interface for calling an action with the `kwil.call()` method.
  */
 export interface CallBody {

--- a/src/core/enums.ts
+++ b/src/core/enums.ts
@@ -44,6 +44,7 @@ export enum PayloadType {
   CALL_ACTION = 'call_action',
   TRANSFER = 'transfer',
   RAW_STATEMENT = 'raw_statement',
+  MAA_EXEC = 'maa_exec',
 }
 
 export enum SerializationType {

--- a/src/core/payload.ts
+++ b/src/core/payload.ts
@@ -22,7 +22,28 @@ import { AccountId } from './network';
 export type AllPayloads =
   | UnencodedActionPayload<PayloadType.CALL_ACTION | PayloadType.EXECUTE_ACTION>
   | TransferPayload
-  | RawStatementPayload;
+  | RawStatementPayload
+  | MAAExecPayload;
+
+/**
+ * `MAAExecPayload` is the wire payload for a `maa_exec` transaction: run one inner action AS a
+ * Modular Agent Address (agent wallet). It is a distinct transaction payload, not an action call —
+ * the outer signer (the wallet's restricted agent or unrestricted owner) signs it, and the node
+ * rewrites `@caller` to `maaAddress` after checking the rule's role and allow-list.
+ *
+ * The field order and types mirror kwil-db's `core/types.MAAExec`; `encodeMAAExec` must serialize it
+ * byte-for-byte identically to that struct's `MarshalBinary` (the layout is a consensus contract).
+ */
+export interface MAAExecPayload {
+  // maaAddress is the 20-byte agent-wallet address whose identity the inner action assumes.
+  maaAddress: Uint8Array;
+  // namespace is the namespace of the inner action (e.g. "main").
+  namespace: string;
+  // action is the inner action name to execute as the wallet.
+  action: string;
+  // arguments are the inner action's arguments (a single call).
+  arguments: EncodedValue[];
+}
 
 export type UnencodedActionPayload<T extends PayloadType.CALL_ACTION | PayloadType.EXECUTE_ACTION> =
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,13 @@ import { NodeKwil } from './client/node/nodeKwil';
 import { WebKwil } from './client/web/webKwil';
 import { generateDBID as _generateDBID } from './utils/dbid';
 import { TxReceipt as _TxReceipt } from './core/tx';
-import { 
+import {
   ActionInput as _ActionInput,
   ActionBody as _ActionBody, CallBody as _CallBody,
   CallBodyNode as _CallBodyNode,
+  MAAExecBody as _MAAExecBody,
   NamedParams as _NamedParams,
-  PositionalParams as _PositionalParams 
+  PositionalParams as _PositionalParams
 } from './core/action';
 import { Transaction as _Transaction } from './core/tx';
 import {
@@ -42,7 +43,7 @@ import { Config as _Config, KwilConfig as _KwilConfig } from './api_client/confi
 import { EthSigner as _EthSigner } from './core/signature';
 import { Kwil as _Kwil } from './client/kwil';
 import { formatEncodedValue as _formatEncodedValue } from './utils/parameterEncoding';
-import { encodeEncodedValue as _encodeEncodedValue } from './utils/kwilEncoding';
+import { encodeEncodedValue as _encodeEncodedValue, encodeMAAExec as _encodeMAAExec } from './utils/kwilEncoding';
 import { EncodedValue as _EncodedValue } from './core/payload';
 
 namespace Types {
@@ -56,6 +57,7 @@ namespace Types {
   export type ActionBody = _ActionBody;
   export type CallBody = _CallBody;
   export type CallBodyNode = _CallBodyNode;
+  export type MAAExecBody = _MAAExecBody;
   export type QueryParams = _QueryParams;
   export type ChainInfo = _ChainInfo;
   export type ChainInfoOpts = _ChainInfoOpts
@@ -117,6 +119,13 @@ namespace Utils {
    * Used for advanced argument encoding scenarios.
    */
   export const encodeEncodedValue = _encodeEncodedValue;
+
+  /**
+   * Serializes a `maa_exec` payload (run an inner action as an agent wallet) to the base64 wire
+   * format, byte-identical to kwil-db's `core/types.MAAExec.MarshalBinary`. Exposed for advanced
+   * use; most callers should use `kwil.maaExec()`.
+   */
+  export const encodeMAAExec = _encodeMAAExec;
 }
 
 export { NodeKwil, WebKwil, KwilSigner, Types, Utils, Client, AdminClient, EnvironmentType };

--- a/src/transaction/payloadTx.ts
+++ b/src/transaction/payloadTx.ts
@@ -15,7 +15,12 @@ import { sha256BytesToBytes } from '../utils/crypto';
 import { objects } from '../utils/objects';
 import { bytesToHex, stringToBytes } from '../utils/serial';
 import { strings } from '../utils/strings';
-import { encodeActionExecution, encodeRawStatement, encodeTransfer } from '../utils/kwilEncoding';
+import {
+  encodeActionExecution,
+  encodeMAAExec,
+  encodeRawStatement,
+  encodeTransfer,
+} from '../utils/kwilEncoding';
 
 export interface PayloadTxOptions {
   payload: AllPayloads;
@@ -230,7 +235,8 @@ Kwil Chain ID: ${tx.body.chain_id}
   private encodePayload(payloadType: PayloadType, payload: AllPayloads): string {
     switch (payloadType) {
       case PayloadType.EXECUTE_ACTION:
-        if (!('action' in payload && 'arguments' in payload)) {
+        // 'dbid' distinguishes an action payload from a MAAExecPayload, which also has action/arguments.
+        if (!('dbid' in payload && 'action' in payload && 'arguments' in payload)) {
           throw new Error('Invalid payload type for EXECUTE_ACTION');
         }
         return encodeActionExecution(payload);
@@ -246,6 +252,12 @@ Kwil Chain ID: ${tx.body.chain_id}
           throw new Error('Invalid payload type for RAW_STATEMENT');
         }
         return encodeRawStatement(payload);
+
+      case PayloadType.MAA_EXEC:
+        if (!('maaAddress' in payload && 'action' in payload)) {
+          throw new Error('Invalid payload type for MAA_EXEC');
+        }
+        return encodeMAAExec(payload);
 
       default:
         throw new Error(`Unsupported payload type: ${payloadType}`);

--- a/src/utils/kwilEncoding.ts
+++ b/src/utils/kwilEncoding.ts
@@ -2,6 +2,7 @@ import { DataInfo } from '../core/database';
 import { AccountId } from '../core/network';
 import {
   EncodedValue,
+  MAAExecPayload,
   RawStatementPayload,
   TransferPayload,
   UnencodedActionPayload,
@@ -152,6 +153,53 @@ export function encodeTransfer(transfer: TransferPayload): string {
   );
 
   return bytesToBase64(concatBytes(encodedVersion, encodedTo, encodedAmount));
+}
+
+/**
+ * Encodes a `MAAExecPayload` (the `maa_exec` transaction) to match kwil-db's
+ * `core/types.MAAExec.MarshalBinary`. The layout is a consensus contract — the node, kwil-js, and the
+ * language SDKs must all serialize it identically — so this is asserted byte-for-byte against the Go
+ * golden vector (`core/types/payloads_maa_test.go`). All integers are little-endian.
+ *
+ * Layout (little-endian throughout):
+ *   uint16 version = 0
+ *   WriteBytes(maaAddress)            // 4-byte length prefix + raw bytes
+ *   WriteString(namespace)            // 4-byte length prefix + utf-8 bytes
+ *   WriteString(action)               // 4-byte length prefix + utf-8 bytes
+ *   uint16 numArgs
+ *   for each arg: WriteBytes(EncodedValue.MarshalBinary())   // a single call, like an action call
+ */
+export function encodeMAAExec(payload: MAAExecPayload): string {
+  const maaExecVersion = 0;
+
+  const encodedVersion = numberToUint16LittleEndian(maaExecVersion);
+  const encodedMaaAddress = prefixBytesLength(payload.maaAddress);
+  const encodedNamespace = prefixBytesLength(stringToBytes(payload.namespace));
+  const encodedAction = prefixBytesLength(stringToBytes(payload.action));
+
+  const encodedNumArgs = numberToUint16LittleEndian(
+    payload.arguments ? payload.arguments.length : 0
+  );
+  let actionArguments: Uint8Array = new Uint8Array();
+
+  payload.arguments?.forEach((a: EncodedValue) => {
+    const aBytes = encodeEncodedValue(a);
+    const prefixedABytes = prefixBytesLength(aBytes);
+
+    actionArguments = concatBytes(actionArguments, prefixedABytes);
+  });
+
+  const encodedActionArguments = concatBytes(encodedNumArgs, actionArguments);
+
+  return bytesToBase64(
+    concatBytes(
+      encodedVersion,
+      encodedMaaAddress,
+      encodedNamespace,
+      encodedAction,
+      encodedActionArguments
+    )
+  );
 }
 
 /**

--- a/tests/unitTests/utils/kwilEncoding.test.ts
+++ b/tests/unitTests/utils/kwilEncoding.test.ts
@@ -1,0 +1,95 @@
+import { encodeEncodedValue, encodeMAAExec } from '../../../src/utils/kwilEncoding';
+import { MAAExecPayload } from '../../../src/core/payload';
+import { PayloadType } from '../../../src/core/enums';
+import { base64ToBytes } from '../../../src/utils/base64';
+import { bytesToHex, stringToBytes } from '../../../src/utils/serial';
+import { concatBytes, numberToUint16LittleEndian, prefixBytesLength } from '../../../src/utils/bytes';
+import { formatEncodedValue } from '../../../src/utils/parameterEncoding';
+
+/**
+ * The MAAExec wire layout is a consensus contract: the node, kwil-js, and the language SDKs must all
+ * serialize it identically (a single byte of divergence rewrites which action runs, or under whose
+ * identity). These tests freeze that layout against the Go golden vector in kwil-db
+ * (core/types/payloads_maa_test.go). The golden vector uses ZERO arguments so its bytes are fully
+ * determined by the MAA-specific framing; argument encoding reuses the shared EncodedValue format
+ * already covered elsewhere, and is pinned structurally below.
+ */
+describe('encodeMAAExec — kwil-db MAAExec.MarshalBinary parity', () => {
+  // Copied verbatim from kwil-db core/types/payloads_maa_test.go (goldenMAAExecHex).
+  const goldenMAAExecHex =
+    '0000' + // uint16 version = 0 (little-endian)
+    '14000000' +
+    '1111111111111111111111111111111111111111' + // WriteBytes(maa_address): len=20, then 20 bytes
+    '04000000' +
+    '6d61696e' + // WriteString("main"): len=4, then "main"
+    '0e000000' +
+    '6f625f706c6163655f6f72646572' + // WriteString("ob_place_order"): len=14, then bytes
+    '0000'; // uint16 numArgs = 0
+
+  test('the enum string value is the wire contract', () => {
+    expect(PayloadType.MAA_EXEC).toBe('maa_exec');
+  });
+
+  test('zero-argument vector is byte-identical to the Go golden vector', () => {
+    const payload: MAAExecPayload = {
+      maaAddress: new Uint8Array(20).fill(0x11),
+      namespace: 'main',
+      action: 'ob_place_order',
+      arguments: [],
+    };
+
+    const bytes = base64ToBytes(encodeMAAExec(payload));
+    expect(bytesToHex(bytes)).toBe(goldenMAAExecHex);
+  });
+
+  test('arguments use the single-call framing: numArgs then per-arg length-prefixed EncodedValue', () => {
+    const maaAddress = new Uint8Array(20).fill(0x22);
+    const arg0 = formatEncodedValue('0xabc');
+    const arg1 = formatEncodedValue(42);
+
+    const payload: MAAExecPayload = {
+      maaAddress,
+      namespace: 'main',
+      action: 'maa_record_event',
+      arguments: [arg0, arg1],
+    };
+
+    const got = base64ToBytes(encodeMAAExec(payload));
+
+    // Reconstruct the expected wire bytes from the same primitives the Go MarshalBinary uses, in
+    // order: version, WriteBytes(maa), WriteString(ns), WriteString(action), uint16 numArgs, then
+    // each argument as WriteBytes(EncodedValue.MarshalBinary()).
+    const expected = concatBytes(
+      numberToUint16LittleEndian(0),
+      prefixBytesLength(maaAddress),
+      prefixBytesLength(stringToBytes('main')),
+      prefixBytesLength(stringToBytes('maa_record_event')),
+      numberToUint16LittleEndian(2),
+      prefixBytesLength(encodeEncodedValue(arg0)),
+      prefixBytesLength(encodeEncodedValue(arg1))
+    );
+
+    expect(bytesToHex(got)).toBe(bytesToHex(expected));
+  });
+
+  test('empty namespace serializes as a present zero-length string (len 0), not the nil sentinel', () => {
+    const payload: MAAExecPayload = {
+      maaAddress: new Uint8Array(20).fill(0x11),
+      namespace: '',
+      action: 'x',
+      arguments: [],
+    };
+
+    const bytes = base64ToBytes(encodeMAAExec(payload));
+    // version(0000) + maa(len20 + 20 bytes) + ns(len 0 => 00000000) + action(len1 + 'x'=78) + numArgs(0000)
+    const expectedHex =
+      '0000' +
+      '14000000' +
+      '1111111111111111111111111111111111111111' +
+      '00000000' +
+      '01000000' +
+      '78' +
+      '0000';
+    expect(bytesToHex(bytes)).toBe(expectedHex);
+  });
+});


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4085

Adds the `maa_exec` transaction to kwil-js so a developer can run one allow-listed action **as** an agent wallet (Modular Agent Address): the wallet's restricted agent or unrestricted owner signs the transaction, and the node looks up the rule, enforces the allow-list for the signer's role, and re-enters the engine with `@caller` rewritten to the wallet. `maa_exec` is a distinct transaction payload, not an action call.

## What this adds

- `PayloadType.MAA_EXEC` (`'maa_exec'`), `MAAExecPayload`, and `encodeMAAExec()` — serialized **byte-for-byte identically** to kwil-db's `core/types.MAAExec.MarshalBinary` (the wire layout is a consensus contract: one divergent byte rewrites which action runs, or under whose identity).
- Public `kwil.maaExec(body, signer)` method on both `NodeKwil` and `WebKwil`, mirroring `execSql`/`transfer`. It normalizes the address (`0x`-hex or raw bytes), defaults an empty namespace to `main`, validates the 20-byte length, and formats positional inputs through the same encoder `execute` uses.
- `Utils.encodeMAAExec` and `Types.MAAExecBody` exports.

## Testing

- New unit tests assert byte-equality against the Go golden vector (`kwil-db core/types/payloads_maa_test.go`), the single-call argument framing, and empty-namespace handling.
- `tsc --noEmit`, the full unit suite, and the CJS + ESM build pass; the built `dist` reproduces the golden vector exactly.

## Context

This completes the kwil-js slice of MAA Problem #9. The sibling slices are already merged:

- <https://github.com/trufnetwork/kwil-db/pull/1712>
- <https://github.com/trufnetwork/sdk-go/pull/193>
- <https://github.com/trufnetwork/sdk-py/pull/122>

The sdk-js wrapper follows once a kwil-js version shipping this is published.
